### PR TITLE
Solves issue "#49 cleanup empty commits from tsk pr for github"

### DIFF
--- a/src/adapters/backend.rs
+++ b/src/adapters/backend.rs
@@ -66,9 +66,9 @@ pub struct BackendPrRecord {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, clap::ValueEnum)]
 pub enum MergeMethod {
-    #[default]
     Merge,
     Squash,
+    #[default]
     Rebase,
 }
 
@@ -160,4 +160,14 @@ pub trait BackendProvider: Send + Sync {
     ) -> Result<(), RiptskError>;
     async fn default_branch(&self, repo: &str) -> Result<String, RiptskError>;
     async fn delete_branch(&self, repo: &str, branch_name: &str) -> Result<(), RiptskError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MergeMethod;
+
+    #[test]
+    fn default_merge_method_is_rebase() {
+        assert_eq!(MergeMethod::default(), MergeMethod::Rebase);
+    }
 }

--- a/src/adapters/git.rs
+++ b/src/adapters/git.rs
@@ -36,6 +36,16 @@ pub trait GitBackend {
         base: &str,
     ) -> Result<u64, RiptskError>;
     fn create_empty_commit(&self, repo: &Path, message: &str) -> Result<(), RiptskError>;
+    fn find_commit_by_subject(
+        &self,
+        repo: &Path,
+        branch: &str,
+        base: &str,
+        subject: &str,
+    ) -> Result<Option<String>, RiptskError>;
+    fn rebase_drop_commit(&self, repo: &Path, commit_sha: &str) -> Result<(), RiptskError>;
+    fn force_push_with_lease(&self, repo: &Path, branch: &str) -> Result<(), RiptskError>;
+    fn force_push(&self, repo: &Path, branch: &str) -> Result<(), RiptskError>;
     fn log_between(&self, repo: &Path, base: &str, head: &str) -> Result<String, RiptskError>;
     fn diff_between(&self, repo: &Path, base: &str, head: &str) -> Result<String, RiptskError>;
 }
@@ -270,6 +280,64 @@ impl GitBackend for CliGit {
             args.push(part);
         }
         run_git_dynamic(repo, &args)
+    }
+
+    fn find_commit_by_subject(
+        &self,
+        repo: &Path,
+        branch: &str,
+        base: &str,
+        subject: &str,
+    ) -> Result<Option<String>, RiptskError> {
+        let range = format!("origin/{base}..{branch}");
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(["log", "--format=%H%n%s", &range])
+            .output()?;
+        if !output.status.success() {
+            return Err(RiptskError::General(
+                "failed to inspect commit subjects".into(),
+            ));
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let mut lines = stdout.lines();
+        while let Some(sha) = lines.next() {
+            let Some(commit_subject) = lines.next() else {
+                break;
+            };
+            if commit_subject == subject {
+                return Ok(Some(sha.to_owned()));
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn rebase_drop_commit(&self, repo: &Path, commit_sha: &str) -> Result<(), RiptskError> {
+        let onto = format!("{commit_sha}^");
+        let status = Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(["rebase", "--onto", &onto, commit_sha, "HEAD"])
+            .status()?;
+        if status.success() {
+            return Ok(());
+        }
+
+        let _ = run_git_dynamic(repo, &["rebase", "--abort"]);
+        Err(RiptskError::General(format!(
+            "failed to drop commit {commit_sha} via rebase"
+        )))
+    }
+
+    fn force_push_with_lease(&self, repo: &Path, branch: &str) -> Result<(), RiptskError> {
+        self.run_git_remote(repo, &["push", "--force-with-lease", "origin", branch])
+    }
+
+    fn force_push(&self, repo: &Path, branch: &str) -> Result<(), RiptskError> {
+        self.run_git_remote(repo, &["push", "--force", "origin", branch])
     }
 
     fn log_between(&self, repo: &Path, base: &str, head: &str) -> Result<String, RiptskError> {

--- a/src/adapters/gitlab.rs
+++ b/src/adapters/gitlab.rs
@@ -162,6 +162,56 @@ impl GitlabProvider {
             .map_err(|error| RiptskError::Unreachable(error.to_string()))?;
         Ok(())
     }
+
+    async fn rebase_and_wait(&self, repo: &str, number: u64) -> Result<(), RiptskError> {
+        let client = self.client().await?;
+
+        let rebase_endpoint = gitlab::api::projects::merge_requests::RebaseMergeRequest::builder()
+            .project(repo)
+            .merge_request(number)
+            .build()
+            .map_err(|e| RiptskError::Config(e.to_string()))?;
+        gitlab::api::ignore(rebase_endpoint)
+            .query_async(&client)
+            .await
+            .map_err(|e| {
+                RiptskError::General(format!("failed to trigger rebase for MR !{number}: {e}"))
+            })?;
+
+        let started = std::time::Instant::now();
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+
+            let poll_endpoint = gitlab::api::projects::merge_requests::MergeRequest::builder()
+                .project(repo)
+                .merge_request(number)
+                .include_rebase_in_progress(true)
+                .build()
+                .map_err(|e| RiptskError::Config(e.to_string()))?;
+            let mr: GitlabMergeRequest = poll_endpoint
+                .query_async(&client)
+                .await
+                .map_err(|e| RiptskError::Unreachable(e.to_string()))?;
+
+            if let Some(ref error) = mr.merge_error
+                && !error.is_empty()
+            {
+                return Err(RiptskError::General(format!(
+                    "rebase failed for MR !{number}: {error}"
+                )));
+            }
+
+            if mr.rebase_in_progress != Some(true) {
+                return Ok(());
+            }
+
+            if started.elapsed() >= std::time::Duration::from_secs(600) {
+                return Err(RiptskError::General(format!(
+                    "timed out waiting for rebase of MR !{number}"
+                )));
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -394,9 +444,23 @@ impl BackendProvider for GitlabProvider {
         commit_message: Option<&str>,
     ) -> Result<(), RiptskError> {
         if method == MergeMethod::Rebase {
-            return Err(RiptskError::General(
-                "GitLab does not support rebase as a merge method. Use merge or squash.".into(),
-            ));
+            self.rebase_and_wait(repo, number).await?;
+            let client = self.client().await?;
+            let mut builder = gitlab::api::projects::merge_requests::MergeMergeRequest::builder();
+            builder.project(repo).merge_request(number);
+            if let Some(message) = commit_message {
+                builder.merge_commit_message(message);
+            }
+            let endpoint = builder
+                .build()
+                .map_err(|e| RiptskError::General(format!("failed to build merge request: {e}")))?;
+            gitlab::api::ignore(endpoint)
+                .query_async(&client)
+                .await
+                .map_err(|e| {
+                    RiptskError::General(format!("failed to merge MR !{number} after rebase: {e}"))
+                })?;
+            return Ok(());
         }
         let client = self.client().await?;
         let mut builder = gitlab::api::projects::merge_requests::MergeMergeRequest::builder();
@@ -426,9 +490,25 @@ impl BackendProvider for GitlabProvider {
         method: MergeMethod,
     ) -> Result<(), RiptskError> {
         if method == MergeMethod::Rebase {
-            return Err(RiptskError::General(
-                "GitLab does not support rebase as a merge method. Use merge or squash.".into(),
-            ));
+            self.rebase_and_wait(repo, number).await?;
+            let client = self.client().await?;
+            let mut builder = gitlab::api::projects::merge_requests::MergeMergeRequest::builder();
+            builder
+                .project(repo)
+                .merge_request(number)
+                .merge_when_pipeline_succeeds(true);
+            let endpoint = builder
+                .build()
+                .map_err(|e| RiptskError::General(format!("failed to build merge request: {e}")))?;
+            gitlab::api::ignore(endpoint)
+                .query_async(&client)
+                .await
+                .map_err(|e| {
+                    RiptskError::General(format!(
+                        "failed to enable auto-merge for MR !{number}: {e}"
+                    ))
+                })?;
+            return Ok(());
         }
         let client = self.client().await?;
         let mut builder = gitlab::api::projects::merge_requests::MergeMergeRequest::builder();
@@ -609,6 +689,10 @@ struct GitlabMergeRequest {
     sha: Option<String>,
     #[serde(default)]
     head_pipeline: Option<GitlabPipeline>,
+    #[serde(default)]
+    rebase_in_progress: Option<bool>,
+    #[serde(default)]
+    merge_error: Option<String>,
     updated_at: String,
     web_url: String,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -160,6 +160,9 @@ pub struct DoneArgs {
     /// Timeout in seconds for waiting (default 600)
     #[arg(long, default_value_t = 600)]
     pub timeout: u64,
+    /// Use --force instead of --force-with-lease when pushing rebased branches
+    #[arg(long)]
+    pub force_push: bool,
 }
 
 #[derive(Debug, Clone, Subcommand)]
@@ -230,6 +233,9 @@ pub struct PrMergeArgs {
     /// Timeout in seconds for waiting (default 600)
     #[arg(long, default_value_t = 600)]
     pub timeout: u64,
+    /// Use --force instead of --force-with-lease when pushing rebased branches
+    #[arg(long)]
+    pub force_push: bool,
 }
 
 #[derive(Debug, Clone, Args, Default)]

--- a/src/commands/done.rs
+++ b/src/commands/done.rs
@@ -57,8 +57,19 @@ pub async fn run(paths: &AppPaths, args: DoneArgs) -> Result<(), RiptskError> {
         auto_merge: args.auto_merge,
         yes: args.yes,
         timeout: args.timeout,
+        force_push: args.force_push,
     };
-    pr::merge_pr_workflow(provider.as_ref(), repo_name, pr_number, &issue, &merge_opts).await?;
+    pr::merge_pr_workflow(
+        provider.as_ref(),
+        &git,
+        backend.backend.clone(),
+        repo_dir.as_path(),
+        repo_name,
+        pr_number,
+        &issue,
+        &merge_opts,
+    )
+    .await?;
 
     let default_branch = provider.default_branch(repo_name).await?;
     git.checkout(repo_dir.as_path(), &default_branch)?;

--- a/src/commands/pr.rs
+++ b/src/commands/pr.rs
@@ -98,7 +98,9 @@ async fn create(paths: &AppPaths, args: PrCreateArgs) -> Result<(), RiptskError>
     git.push_with_upstream(repo.as_path(), &branch)?;
 
     let mut skip_ai = false;
-    if git.commits_ahead_of_base(repo.as_path(), &branch, &default_branch)? == 0 {
+    if backend.backend == Backend::Github
+        && git.commits_ahead_of_base(repo.as_path(), &branch, &default_branch)? == 0
+    {
         if git.has_staged_changes(repo.as_path())? {
             return Err(RiptskError::General(
                 "branch has no commits but has staged changes; commit or unstage them first".into(),
@@ -181,6 +183,8 @@ async fn merge(paths: &AppPaths, args: PrMergeArgs) -> Result<(), RiptskError> {
     let config = load_config(paths.config_path().as_std_path()).map_err(RiptskError::Other)?;
     let (_path, issue) = resolve_issue(paths, &config, &args.scope, args.id.as_deref())?;
     let backend = resolve_hosted_backend(&config, &issue)?;
+    let git = CliGit::with_auth(resolve_git_auth(backend));
+    let repo_path = current_repo()?;
     let provider = build_provider_for_backend(backend)?;
     let repo_name = backend.repo.as_deref().unwrap_or_default();
     let pr_number = resolve_pr_number(provider.as_ref(), repo_name, &issue).await?;
@@ -189,9 +193,20 @@ async fn merge(paths: &AppPaths, args: PrMergeArgs) -> Result<(), RiptskError> {
         auto_merge: args.auto_merge,
         yes: args.yes,
         timeout: args.timeout,
+        force_push: args.force_push,
     };
 
-    merge_pr_workflow(provider.as_ref(), repo_name, pr_number, &issue, &opts).await
+    merge_pr_workflow(
+        provider.as_ref(),
+        &git,
+        backend.backend.clone(),
+        repo_path.as_path(),
+        repo_name,
+        pr_number,
+        &issue,
+        &opts,
+    )
+    .await
 }
 
 async fn edit(paths: &AppPaths, args: PrEditArgs) -> Result<(), RiptskError> {
@@ -272,10 +287,15 @@ pub(crate) struct MergeOptions {
     pub auto_merge: bool,
     pub yes: bool,
     pub timeout: u64,
+    pub force_push: bool,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn merge_pr_workflow(
     provider: &dyn BackendProvider,
+    git: &dyn GitBackend,
+    backend_kind: Backend,
+    repo_path: &Path,
     repo_name: &str,
     pr_number: u64,
     issue: &IssueDocument,
@@ -299,6 +319,40 @@ pub(crate) async fn merge_pr_workflow(
     {
         crate::ui::warn("aborted");
         return Ok(());
+    }
+
+    // Cleanup empty bootstrap commit for GitHub before merge
+    if backend_kind == Backend::Github
+        && let Some(branch) = issue.frontmatter.branch.as_deref()
+    {
+        let default_branch = provider.default_branch(repo_name).await?;
+        let subject = EMPTY_BRANCH_COMMIT_MESSAGE
+            .lines()
+            .next()
+            .unwrap_or_default();
+        if let Some(sha) =
+            git.find_commit_by_subject(repo_path, branch, &default_branch, subject)?
+        {
+            // Ensure we are on the issue branch before rewriting history
+            let current = git.current_branch(repo_path)?;
+            if current != branch {
+                git.checkout(repo_path, branch)?;
+            }
+            crate::ui::info("dropping empty bootstrap commit...");
+            git.rebase_drop_commit(repo_path, &sha)?;
+
+            if git.commits_ahead_of_base(repo_path, branch, &default_branch)? == 0 {
+                return Err(RiptskError::General(
+                    "branch has no real commits; nothing to merge".into(),
+                ));
+            }
+
+            if opts.force_push {
+                git.force_push(repo_path, branch)?;
+            } else {
+                git.force_push_with_lease(repo_path, branch)?;
+            }
+        }
     }
 
     if opts.auto_merge {

--- a/tests/cmd_foundation.rs
+++ b/tests/cmd_foundation.rs
@@ -32,6 +32,7 @@ fn done_help_prints_expected_flags() {
         .success()
         .stdout(predicate::str::contains("--merge-method"))
         .stdout(predicate::str::contains("--auto-merge"))
+        .stdout(predicate::str::contains("--force-push"))
         .stdout(predicate::str::contains("--timeout"))
         .stdout(predicate::str::contains("--yes"));
 }
@@ -45,6 +46,7 @@ fn pr_merge_help_prints_expected_flags() {
         .success()
         .stdout(predicate::str::contains("--merge-method"))
         .stdout(predicate::str::contains("--auto-merge"))
+        .stdout(predicate::str::contains("--force-push"))
         .stdout(predicate::str::contains("--timeout"))
         .stdout(predicate::str::contains("--yes"));
 }


### PR DESCRIPTION
Closes #49
Closes #50 

## Summary

Implements rebase workflow enforcement and empty commit cleanup across GitHub and GitLab backends. Changes the default merge method to Rebase and adds git adapter methods to support the rebase-drop-commit pattern for GitHub PR merges.

## Key Changes

- Changed default `MergeMethod` from `Merge` to `Rebase` with test coverage
- Added git adapter methods for rebase operations:
  - `find_commit_by_subject` — locate commits by message in a branch range
  - `rebase_drop_commit` — remove commits via non-interactive rebase
  - `force_push_with_lease` — safer force-push using `--force-with-lease`
  - `force_push` — standard force-push for explicit override
- Implemented GitLab rebase merge support via `rebase_and_wait` method that triggers rebase and polls for completion
- Updated GitLab's `merge_pr` and `enable_auto_merge` to support `MergeMethod::Rebase`
- Enables GitHub-specific empty commit cleanup via rebase-drop pattern (GitLab handles empty commits natively)