### PR TITLE
Solves issue "#72 Add `start` command to initialize new issue with branch and PR"

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -58,6 +58,8 @@ pub enum Commands {
     Branch(BranchArgs),
     /// Complete an issue: merge PR, clean up branches, close issue (convenience wrapper — see `tsk pr merge`, `tsk branch -D`, `tsk close`)
     Done(DoneArgs),
+    /// Start working on a new issue: create issue, branch, and PR (convenience wrapper — see `tsk new`, `tsk branch`, `tsk pr`)
+    Start(StartArgs),
     /// Create, edit, or show a pull/merge request
     Pr(PrArgs),
     /// Display or manage board views
@@ -159,6 +161,37 @@ pub struct DoneArgs {
     /// Use --force instead of --force-with-lease when pushing rebased branches
     #[arg(long)]
     pub force_push: bool,
+}
+
+#[derive(Debug, Clone, Args, Default)]
+pub struct StartArgs {
+    /// Issue title (positional)
+    #[arg(conflicts_with = "title")]
+    pub title_pos: Option<String>,
+    /// Issue title (or enter interactively)
+    #[arg(short = 't', long)]
+    pub title: Option<String>,
+    /// Target project
+    #[arg(short = 'p', long)]
+    pub project: Option<String>,
+    /// Board to assign
+    #[arg(short = 'b', long)]
+    pub board: Option<String>,
+    /// Initial status
+    #[arg(short = 's', long)]
+    pub status: Option<String>,
+    /// Priority level
+    #[arg(short = 'P', long)]
+    pub priority: Option<String>,
+    /// Template to use
+    #[arg(short = 'T', long)]
+    pub template: Option<String>,
+    /// Disable AI-assisted content generation (AI is on by default)
+    #[arg(long)]
+    pub no_ai: bool,
+    /// Open in $EDITOR after creation
+    #[arg(short = 'e', long)]
+    pub edit: bool,
 }
 
 #[derive(Debug, Clone, Subcommand)]
@@ -776,6 +809,45 @@ mod tests {
             panic!("expected new command");
         };
         assert!(args.edit);
+    }
+
+    #[test]
+    fn start_positional_title_parses() {
+        let cli = Cli::try_parse_from(["tsk", "start", "my title"]).expect("parse");
+        let Commands::Start(args) = cli.command.expect("command") else {
+            panic!("expected start command");
+        };
+        assert_eq!(args.title_pos.as_deref(), Some("my title"));
+        assert!(args.title.is_none());
+    }
+
+    #[test]
+    fn start_no_ai_parses() {
+        let cli = Cli::try_parse_from(["tsk", "start", "--no-ai", "my title"]).expect("parse");
+        let Commands::Start(args) = cli.command.expect("command") else {
+            panic!("expected start command");
+        };
+        assert_eq!(args.title_pos.as_deref(), Some("my title"));
+        assert!(args.no_ai);
+    }
+
+    #[test]
+    fn start_edit_flag_parses() {
+        let cli = Cli::try_parse_from(["tsk", "start", "-e", "my title"]).expect("parse");
+        let Commands::Start(args) = cli.command.expect("command") else {
+            panic!("expected start command");
+        };
+        assert_eq!(args.title_pos.as_deref(), Some("my title"));
+        assert!(args.edit);
+    }
+
+    #[test]
+    fn start_project_parses() {
+        let cli = Cli::try_parse_from(["tsk", "start", "-p", "myproject"]).expect("parse");
+        let Commands::Start(args) = cli.command.expect("command") else {
+            panic!("expected start command");
+        };
+        assert_eq!(args.project.as_deref(), Some("myproject"));
     }
 
     #[test]

--- a/src/commands/branch.rs
+++ b/src/commands/branch.rs
@@ -26,8 +26,19 @@ async fn create_branch(paths: &AppPaths, args: BranchArgs) -> Result<(), RiptskE
     let Some(id) = id_resolution::require_id(paths, &config, &cwd, id, &scope)? else {
         return Ok(());
     };
-    let path = issue_store::find_issue(paths, &id)?;
-    let mut issue = crate::commands::issues::load_issue_or_conflict_error(path.as_std_path(), &id)?;
+    let slug = create_branch_for_issue(paths, &id).await?;
+    println!("{slug}");
+    Ok(())
+}
+
+pub(crate) async fn create_branch_for_issue(
+    paths: &AppPaths,
+    id: &str,
+) -> Result<String, RiptskError> {
+    paths.require_initialized()?;
+    let config = load_config(paths.config_path().as_std_path()).map_err(RiptskError::Other)?;
+    let path = issue_store::find_issue(paths, id)?;
+    let mut issue = crate::commands::issues::load_issue_or_conflict_error(path.as_std_path(), id)?;
 
     let backend = config
         .backends
@@ -82,8 +93,7 @@ async fn create_branch(paths: &AppPaths, args: BranchArgs) -> Result<(), RiptskE
         ),
         &[path.as_std_path()],
     )?;
-    println!("{slug}");
-    Ok(())
+    Ok(slug)
 }
 
 async fn delete_branch(paths: &AppPaths, args: BranchArgs) -> Result<(), RiptskError> {

--- a/src/commands/issues.rs
+++ b/src/commands/issues.rs
@@ -250,7 +250,10 @@ fn priority_color(priority: Option<&Priority>) -> Color {
     }
 }
 
-pub async fn new(paths: &AppPaths, args: NewArgs) -> Result<(), RiptskError> {
+pub(crate) async fn create_issue_from_args(
+    paths: &AppPaths,
+    args: NewArgs,
+) -> Result<(IssueDocument, camino::Utf8PathBuf), RiptskError> {
     paths.require_initialized()?;
     let config = load_config(paths.config_path().as_std_path()).map_err(RiptskError::Other)?;
     let mut args = args;
@@ -345,7 +348,6 @@ pub async fn new(paths: &AppPaths, args: NewArgs) -> Result<(), RiptskError> {
         ),
         &[issue_path.as_std_path()],
     )?;
-    print_issue_created(&issue);
     if edit {
         service.edit_issue(Some(issue.frontmatter.id.clone()))?;
         maybe_auto_commit(
@@ -359,6 +361,12 @@ pub async fn new(paths: &AppPaths, args: NewArgs) -> Result<(), RiptskError> {
             &[issue_path.as_std_path()],
         )?;
     }
+    Ok((issue, issue_path))
+}
+
+pub async fn new(paths: &AppPaths, args: NewArgs) -> Result<(), RiptskError> {
+    let (issue, _path) = create_issue_from_args(paths, args).await?;
+    print_issue_created(&issue);
     Ok(())
 }
 
@@ -400,7 +408,7 @@ fn resolve_project_repo_path(
     cwd.to_path_buf()
 }
 
-fn print_issue_created(issue: &IssueDocument) {
+pub(crate) fn print_issue_created(issue: &IssueDocument) {
     if !crate::ui::is_tty() {
         println!("{}", issue.frontmatter.id);
         return;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod issues;
 pub mod pr;
 pub mod recur;
 pub mod register;
+pub mod start;
 pub mod sync_cmd;
 pub mod templates;
 pub mod views;

--- a/src/commands/pr.rs
+++ b/src/commands/pr.rs
@@ -49,7 +49,7 @@ pub async fn run(paths: &AppPaths, args: PrArgs) -> Result<(), RiptskError> {
     }
 }
 
-async fn create(paths: &AppPaths, args: PrCreateArgs) -> Result<(), RiptskError> {
+pub(crate) async fn create(paths: &AppPaths, args: PrCreateArgs) -> Result<(), RiptskError> {
     paths.require_initialized()?;
     let config = load_config(paths.config_path().as_std_path()).map_err(RiptskError::Other)?;
     let repo = current_repo()?;

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -1,0 +1,42 @@
+use crate::cli::{NewArgs, PrCreateArgs, ScopeArgs, StartArgs};
+use crate::commands::{branch, issues, pr};
+use crate::error::RiptskError;
+use crate::paths::AppPaths;
+
+pub async fn run(paths: &AppPaths, args: StartArgs) -> Result<(), RiptskError> {
+    paths.require_initialized()?;
+
+    // Convert StartArgs to NewArgs with AI enabled by default
+    let new_args = NewArgs {
+        title_pos: args.title_pos,
+        title: args.title,
+        project: args.project,
+        board: args.board,
+        status: args.status,
+        priority: args.priority,
+        template: args.template,
+        ai: !args.no_ai,
+        edit: args.edit,
+    };
+
+    // Step 1: Create issue
+    let (issue, _issue_path) = issues::create_issue_from_args(paths, new_args).await?;
+    let id = issue.frontmatter.id.clone();
+    issues::print_issue_created(&issue);
+
+    // Step 2: Create branch
+    let _branch = branch::create_branch_for_issue(paths, &id).await?;
+
+    // Step 3: Create PR
+    pr::create(
+        paths,
+        PrCreateArgs {
+            scope: ScopeArgs::default(),
+            id: Some(id),
+            no_ai: args.no_ai,
+        },
+    )
+    .await?;
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,6 +110,13 @@ fn run() -> Result<(), RiptskError> {
                 .context("failed to construct tokio runtime")?;
             runtime.block_on(commands::done::run(&paths, args))
         }
+        Commands::Start(args) => {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .context("failed to construct tokio runtime")?;
+            runtime.block_on(commands::start::run(&paths, args))
+        }
         Commands::Pr(args) => {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()


### PR DESCRIPTION
Closes #72

## Summary

This PR implements the `start` command, a convenience wrapper that orchestrates creating a new issue, generating a branch, and opening a PR in a single operation. This completes the inverse workflow to the existing `done` command.

## Key Changes

- **New `StartArgs` struct** in `cli.rs` with options for title (positional or `--title`), project, board, status, priority, template, `--no-ai` flag, and `--edit` flag
- **Refactored `branch::create_branch()`** to extract `create_branch_for_issue()` as a public function for reuse by the start command
- **Refactored `issues::new()`** to extract `create_issue_from_args()` as a public function, now returns the created issue and path for composition
- **Made `pr::create()` public** to enable orchestration from the start command
- **Added `commands/start.rs` module** with orchestration logic that chains issue creation, branch creation, and PR creation
- **Added comprehensive tests** for CLI parsing (positional title, `--no-ai`, `--edit`, `--project` flags)
- **Updated `commands/mod.rs`** to include the new start module

The implementation follows the existing patterns in the codebase and maintains consistency with the `done` command structure for a cohesive user experience.