### PR TITLE
Solves issue "#92 Add work-clone functionality for parallel issue development"

### DIFF
--- a/src/adapters/git.rs
+++ b/src/adapters/git.rs
@@ -8,6 +8,7 @@ pub trait GitBackend {
     fn init(&self, path: &Path) -> Result<(), RiptskError>;
     fn add(&self, repo: &Path, files: &[&Path]) -> Result<(), RiptskError>;
     fn commit(&self, repo: &Path, message: &str) -> Result<(), RiptskError>;
+    fn repo_root(&self, cwd: &Path) -> Result<std::path::PathBuf, RiptskError>;
     fn merge_file(&self, local: &Path, base: &Path, remote: &Path) -> Result<String, RiptskError>;
     fn has_changes(&self, repo: &Path) -> Result<bool, RiptskError>;
     fn has_uncommitted_changes(&self, repo: &Path) -> Result<bool, RiptskError>;
@@ -57,6 +58,12 @@ pub trait GitBackend {
     fn diff_between(&self, repo: &Path, base: &str, head: &str) -> Result<String, RiptskError>;
     fn working_tree_diff(&self, repo: &Path) -> Result<String, RiptskError>;
     fn head_sha(&self, repo: &Path) -> Result<String, RiptskError>;
+    fn clone_with_reference(
+        &self,
+        reference_repo: &Path,
+        remote_url: &str,
+        target_dir: &Path,
+    ) -> Result<(), RiptskError>;
 }
 
 #[derive(Debug, Clone, Default)]
@@ -103,11 +110,52 @@ impl CliGit {
         }
         status_to_result(command.status()?)
     }
+
+    fn prepare_auth_command(&self) -> Result<(Command, Option<tempfile::TempPath>), RiptskError> {
+        let mut command = Command::new("git");
+        let Some(auth) = self.auth.as_ref() else {
+            return Ok((command, None));
+        };
+
+        let mut askpass = tempfile::NamedTempFile::new().map_err(RiptskError::Io)?;
+        askpass
+            .write_all(build_askpass_script(&auth.token).as_bytes())
+            .map_err(RiptskError::Io)?;
+        askpass.flush().map_err(RiptskError::Io)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(askpass.path(), std::fs::Permissions::from_mode(0o700))
+                .map_err(RiptskError::Io)?;
+        }
+        let askpass_path = askpass.into_temp_path();
+        command
+            .env("GIT_ASKPASS", &askpass_path)
+            .env("GIT_TERMINAL_PROMPT", "0");
+        Ok((command, Some(askpass_path)))
+    }
 }
 
 impl GitBackend for CliGit {
     fn init(&self, path: &Path) -> Result<(), RiptskError> {
         run_git(path, ["init"])
+    }
+
+    fn repo_root(&self, cwd: &Path) -> Result<std::path::PathBuf, RiptskError> {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(cwd)
+            .args(["rev-parse", "--show-toplevel"])
+            .output()?;
+        if output.status.success() {
+            Ok(std::path::PathBuf::from(
+                String::from_utf8_lossy(&output.stdout).trim(),
+            ))
+        } else {
+            Err(RiptskError::General(
+                "failed to determine git repository root".into(),
+            ))
+        }
     }
 
     fn add(&self, repo: &Path, files: &[&Path]) -> Result<(), RiptskError> {
@@ -447,6 +495,22 @@ impl GitBackend for CliGit {
         Ok(truncate_diff(
             String::from_utf8_lossy(&output.stdout).trim().to_owned(),
         ))
+    }
+
+    fn clone_with_reference(
+        &self,
+        reference_repo: &Path,
+        remote_url: &str,
+        target_dir: &Path,
+    ) -> Result<(), RiptskError> {
+        let (mut command, _askpass_path) = self.prepare_auth_command()?;
+        command
+            .arg("clone")
+            .arg("--reference")
+            .arg(reference_repo)
+            .arg(remote_url)
+            .arg(target_dir);
+        status_to_result(command.status()?)
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -56,6 +56,10 @@ pub enum Commands {
     Path(IdArgs),
     /// Create, switch to, or delete an issue branch
     Branch(BranchArgs),
+    /// Create a work-clone for an issue
+    Clone(CloneArgs),
+    /// Push changes and remove the current work-clone
+    Unclone(UncloneArgs),
     /// Complete an issue: merge PR, clean up branches, close issue (convenience wrapper — see `tsk pr merge`, `tsk branch -D`, `tsk close`)
     Done(DoneArgs),
     /// Start working on a new issue: create issue, branch, and PR (convenience wrapper — see `tsk new`, `tsk branch`, `tsk pr`)
@@ -128,6 +132,21 @@ pub struct BranchArgs {
     /// Skip confirmation prompt (for -d/-D)
     #[arg(short = 'y', long = "yes")]
     pub yes: bool,
+}
+
+#[derive(Debug, Clone, Args, Default)]
+pub struct CloneArgs {
+    #[command(flatten)]
+    pub scope: ScopeArgs,
+    /// Issue ID
+    pub id: Option<String>,
+}
+
+#[derive(Debug, Clone, Args, Default)]
+pub struct UncloneArgs {
+    /// Discard uncommitted changes before pushing
+    #[arg(short = 'f', long)]
+    pub force: bool,
 }
 
 #[derive(Debug, Clone, Args, Default)]

--- a/src/commands/clone_cmd.rs
+++ b/src/commands/clone_cmd.rs
@@ -1,0 +1,120 @@
+use crate::adapters::git::{CliGit, GitBackend};
+use crate::cli::CloneArgs;
+use crate::commands::branch::{backend_issue_number, cwd_utf8};
+use crate::config::load_config;
+use crate::domain::work_clone::WorkCloneMarker;
+use crate::error::RiptskError;
+use crate::models::Backend;
+use crate::paths::AppPaths;
+use crate::services::auto_commit::maybe_auto_commit;
+use crate::services::backend_mapping::{
+    build_version_control, resolve_git_auth, resolve_vc_for_backend,
+};
+use crate::services::id_resolution;
+use crate::services::issue_service::generate_branch_slug;
+use crate::storage::{frontmatter, issue_store, work_clone};
+
+pub async fn run(paths: &AppPaths, args: CloneArgs) -> Result<(), RiptskError> {
+    paths.require_initialized()?;
+    let config = load_config(paths.config_path().as_std_path()).map_err(RiptskError::Other)?;
+    let cwd = cwd_utf8();
+    let Some(id) = id_resolution::require_id(paths, &config, &cwd, args.id, &args.scope)? else {
+        return Ok(());
+    };
+
+    let path = issue_store::find_issue(paths, &id)?;
+    let mut issue = crate::commands::issues::load_issue_or_conflict_error(path.as_std_path(), &id)?;
+    let backend = config
+        .backends
+        .iter()
+        .find(|b| b.name == issue.frontmatter.project)
+        .ok_or_else(|| RiptskError::Unregistered(issue.frontmatter.project.clone()))?;
+    if backend.backend == Backend::Local {
+        return Err(RiptskError::Config(
+            "cannot create remote branch for local-only project".into(),
+        ));
+    }
+
+    let issue_number = backend_issue_number(backend, &issue)?;
+    let slug = generate_branch_slug(issue_number, &issue.frontmatter.title);
+
+    let (vc_provider, vc_backend, vc_issue_id) = if backend.backend == Backend::Jira {
+        let (provider, vc_backend) =
+            resolve_vc_for_backend(backend, &config)?.ok_or_else(|| {
+                RiptskError::Config(format!(
+                    "No version control backend configured for project '{}'. \
+                     Add 'vc: <github-or-gitlab-backend>' to the backend config.",
+                    backend.name
+                ))
+            })?;
+        (provider, vc_backend.clone(), None)
+    } else {
+        let provider = build_version_control(backend)?;
+        (provider, backend.clone(), Some(issue_number))
+    };
+
+    let auth = resolve_git_auth(&vc_backend);
+    let git = CliGit::with_auth(auth);
+    let repo_name = vc_backend.repo.as_deref().unwrap_or_default();
+    let base = vc_provider.default_branch(repo_name).await?;
+
+    match vc_provider
+        .create_branch(repo_name, &slug, &base, vc_issue_id)
+        .await
+    {
+        Ok(()) => {}
+        Err(ref error) if error.to_string().to_lowercase().contains("already exists") => {
+            crate::ui::info("remote branch already exists, continuing with work-clone creation");
+        }
+        Err(error) => return Err(error),
+    }
+
+    issue.frontmatter.id_slug = Some(slug.clone());
+    issue.frontmatter.branch = Some(slug.clone());
+    frontmatter::save_issue(path.as_std_path(), &issue).map_err(RiptskError::Other)?;
+    maybe_auto_commit(
+        &config,
+        &git,
+        paths.riptsk_repo.as_std_path(),
+        &format!(
+            "riptsk: branch {} - {}",
+            issue.frontmatter.id, issue.frontmatter.title
+        ),
+        &[path.as_std_path()],
+    )?;
+
+    let repo_root = git.repo_root(std::env::current_dir()?.as_path())?;
+    let remote_url = git.remote_url(repo_root.as_path(), "origin")?;
+    let parent = repo_root
+        .parent()
+        .ok_or_else(|| RiptskError::General("repository root has no parent directory".into()))?;
+    let repo_dir_name = repo_root
+        .file_name()
+        .and_then(|value| value.to_str())
+        .ok_or_else(|| {
+            RiptskError::General("repository root has no valid directory name".into())
+        })?;
+    let target_path = parent.join(format!("{repo_dir_name}.{slug}"));
+    if target_path.exists() {
+        return Err(RiptskError::General(format!(
+            "work-clone target already exists: {}",
+            target_path.display()
+        )));
+    }
+
+    git.clone_with_reference(repo_root.as_path(), &remote_url, target_path.as_path())?;
+    git.fetch_and_checkout_tracking(target_path.as_path(), &slug)?;
+    work_clone::save_marker(
+        target_path.as_path(),
+        &WorkCloneMarker {
+            main_repo_path: repo_root.to_string_lossy().to_string(),
+            branch: slug.clone(),
+            issue_id: id,
+            remote_url,
+        },
+    )?;
+
+    crate::ui::success(&format!("created work-clone at {}", target_path.display()));
+    crate::ui::info(&format!("cd {}", target_path.display()));
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod ai;
 pub mod branch;
+pub mod clone_cmd;
 pub mod config_cmd;
 pub mod done;
 pub mod hooks;
@@ -11,4 +12,5 @@ pub mod register;
 pub mod start;
 pub mod sync_cmd;
 pub mod templates;
+pub mod unclone;
 pub mod views;

--- a/src/commands/unclone.rs
+++ b/src/commands/unclone.rs
@@ -1,0 +1,33 @@
+use crate::adapters::git::{CliGit, GitBackend};
+use crate::cli::UncloneArgs;
+use crate::error::RiptskError;
+use crate::paths::AppPaths;
+use crate::storage::work_clone;
+use std::path::PathBuf;
+
+pub fn run(_paths: &AppPaths, args: UncloneArgs) -> Result<(), RiptskError> {
+    let git = CliGit::new();
+    let repo_root = git.repo_root(std::env::current_dir()?.as_path())?;
+    let marker = work_clone::load_marker(repo_root.as_path())?
+        .ok_or_else(|| RiptskError::General("not a work-clone".into()))?;
+    let main_repo_path = PathBuf::from(&marker.main_repo_path);
+
+    if !main_repo_path.exists() {
+        return Err(RiptskError::General(format!(
+            "main repo path does not exist: {}",
+            main_repo_path.display()
+        )));
+    }
+
+    if !args.force && git.has_uncommitted_changes(repo_root.as_path())? {
+        return Err(RiptskError::General(
+            "working tree is dirty; commit or stash changes before running `tsk unclone`, or use --force to discard them".into(),
+        ));
+    }
+
+    git.push(repo_root.as_path())?;
+    crate::ui::success(&format!("pushed {} and removing work-clone", marker.branch));
+    std::fs::remove_dir_all(&repo_root)?;
+    println!("cd {}", main_repo_path.display());
+    Ok(())
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -2,3 +2,4 @@ pub mod backend_state;
 pub mod id_map;
 pub mod issue;
 pub mod session;
+pub mod work_clone;

--- a/src/domain/work_clone.rs
+++ b/src/domain/work_clone.rs
@@ -1,0 +1,9 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkCloneMarker {
+    pub main_repo_path: String,
+    pub branch: String,
+    pub issue_id: String,
+    pub remote_url: String,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,6 +103,14 @@ fn run() -> Result<(), RiptskError> {
                 .context("failed to construct tokio runtime")?;
             runtime.block_on(commands::branch::branch(&paths, args))
         }
+        Commands::Clone(args) => {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .context("failed to construct tokio runtime")?;
+            runtime.block_on(commands::clone_cmd::run(&paths, args))
+        }
+        Commands::Unclone(args) => commands::unclone::run(&paths, args),
         Commands::Done(args) => {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -2,3 +2,4 @@ pub mod cache;
 pub mod frontmatter;
 pub mod issue_store;
 pub mod session;
+pub mod work_clone;

--- a/src/storage/work_clone.rs
+++ b/src/storage/work_clone.rs
@@ -1,0 +1,70 @@
+use crate::domain::work_clone::WorkCloneMarker;
+use crate::error::RiptskError;
+use anyhow::Context;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub fn marker_path(repo_root: &Path) -> PathBuf {
+    repo_root.join(".git").join("tsk-work-clone.json")
+}
+
+pub fn load_marker(repo_root: &Path) -> Result<Option<WorkCloneMarker>, RiptskError> {
+    let path = marker_path(repo_root);
+    match fs::read_to_string(&path) {
+        Ok(content) => serde_json::from_str(&content)
+            .map(Some)
+            .with_context(|| format!("failed to parse {}", path.display()))
+            .map_err(RiptskError::Other),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+pub fn save_marker(repo_root: &Path, marker: &WorkCloneMarker) -> Result<(), RiptskError> {
+    let path = marker_path(repo_root);
+    let content =
+        serde_json::to_string_pretty(marker).map_err(|error| RiptskError::Other(error.into()))?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, format!("{content}\n"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{load_marker, save_marker};
+    use crate::domain::work_clone::WorkCloneMarker;
+    use tempfile::tempdir;
+
+    #[test]
+    fn load_marker_returns_none_when_missing() {
+        let temp = tempdir().expect("temp dir");
+
+        let marker = load_marker(temp.path()).expect("load marker");
+
+        assert!(marker.is_none());
+    }
+
+    #[test]
+    fn marker_round_trip() {
+        let temp = tempdir().expect("temp dir");
+        std::fs::create_dir_all(temp.path().join(".git")).expect("git dir");
+        let marker = WorkCloneMarker {
+            main_repo_path: "/tmp/main".into(),
+            branch: "42-test-branch".into(),
+            issue_id: "42".into(),
+            remote_url: "git@example.com:org/repo.git".into(),
+        };
+
+        save_marker(temp.path(), &marker).expect("save marker");
+        let loaded = load_marker(temp.path())
+            .expect("load marker")
+            .expect("marker present");
+
+        assert_eq!(loaded.main_repo_path, marker.main_repo_path);
+        assert_eq!(loaded.branch, marker.branch);
+        assert_eq!(loaded.issue_id, marker.issue_id);
+        assert_eq!(loaded.remote_url, marker.remote_url);
+    }
+}


### PR DESCRIPTION
Closes #92

## Summary

This PR implements work-clone functionality enabling developers to create isolated repository clones for individual issues. This supports parallel development workflows by allowing multiple issues to be worked on simultaneously without branch conflicts in the main repository.

The implementation adds two new CLI commands (`tsk clone` and `tsk unclone`) that manage the creation and cleanup of work-clone directories. Authentication is handled transparently via `GIT_ASKPASS` for private repositories.

## Key Changes

- **GitBackend trait enhancements**: Added `repo_root()` method to resolve git repository root and `clone_with_reference()` method for efficient cloning with reference repositories
- **Authentication handling**: Implemented `prepare_auth_command()` helper that creates temporary askpass scripts for secure credential passing during git operations
- **CLI commands**: Added `Clone` and `Unclone` command variants with appropriate argument structures
  - `tsk clone [ID]` - Creates a work-clone for the specified issue
  - `tsk unclone [--force]` - Pushes changes and removes the current work-clone
- **Clone command implementation**: New `clone_cmd.rs` module that orchestrates:
  - Issue resolution and configuration loading
  - Backend and version control provider detection
  - Remote branch creation with proper naming convention
  - Integration with existing issue and branch management systems
- **Permission handling**: Unix file permissions set to `0o700` for temporary askpass scripts

This lays the groundwork for the merge-queue feature to manage coordinated multi-feature development workflows.