### PR TITLE
Solves issue "#45 auto solve task selection from active branch"

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,6 +27,8 @@ pub struct ScopeArgs {
 pub struct IdArgs {
     #[command(flatten)]
     pub scope: ScopeArgs,
+    #[arg(short = 'i', long = "pick")]
+    pub pick: bool,
     /// Issue ID (or pick interactively if omitted)
     pub id: Option<String>,
 }
@@ -118,6 +120,9 @@ pub struct BranchArgs {
     #[command(flatten)]
     pub scope: ScopeArgs,
 
+    #[arg(short = 'i', long = "pick", conflicts_with_all = ["delete", "force_delete"])]
+    pub pick: bool,
+
     /// Target branch name or issue ID
     pub id: Option<String>,
 
@@ -138,6 +143,8 @@ pub struct BranchArgs {
 pub struct CloneArgs {
     #[command(flatten)]
     pub scope: ScopeArgs,
+    #[arg(short = 'i', long = "pick")]
+    pub pick: bool,
     /// Issue ID
     pub id: Option<String>,
 }
@@ -163,6 +170,8 @@ pub struct PrArgs {
 pub struct DoneArgs {
     #[command(flatten)]
     pub scope: ScopeArgs,
+    #[arg(short = 'i', long = "pick")]
+    pub pick: bool,
     /// Issue ID (or pick interactively)
     pub id: Option<String>,
     /// Merge method (merge, squash, rebase)
@@ -321,6 +330,8 @@ pub struct NewArgs {
 pub struct StatusArgs {
     #[command(flatten)]
     pub scope: ScopeArgs,
+    #[arg(short = 'i', long = "pick")]
+    pub pick: bool,
     /// Issue ID
     pub id: Option<String>,
     /// Target status
@@ -889,6 +900,85 @@ mod tests {
         };
         assert_eq!(args.id.as_deref(), Some("42"));
         assert_eq!(args.status.as_deref(), Some("in-progress"));
+    }
+
+    #[test]
+    fn show_long_pick_parses() {
+        let cli = Cli::try_parse_from(["tsk", "show", "--pick"]).expect("parse");
+        let Commands::Show(args) = cli.command.expect("command") else {
+            panic!("expected show command");
+        };
+        assert!(args.pick);
+        assert!(args.id.is_none());
+    }
+
+    #[test]
+    fn show_short_pick_parses() {
+        let cli = Cli::try_parse_from(["tsk", "show", "-i"]).expect("parse");
+        let Commands::Show(args) = cli.command.expect("command") else {
+            panic!("expected show command");
+        };
+        assert!(args.pick);
+        assert!(args.id.is_none());
+    }
+
+    #[test]
+    fn edit_short_pick_parses() {
+        let cli = Cli::try_parse_from(["tsk", "edit", "-i"]).expect("parse");
+        let Commands::Edit(args) = cli.command.expect("command") else {
+            panic!("expected edit command");
+        };
+        assert!(args.pick);
+        assert!(args.id.is_none());
+    }
+
+    #[test]
+    fn done_pick_parses() {
+        let cli = Cli::try_parse_from(["tsk", "done", "--pick"]).expect("parse");
+        let Commands::Done(args) = cli.command.expect("command") else {
+            panic!("expected done command");
+        };
+        assert!(args.pick);
+        assert!(args.id.is_none());
+    }
+
+    #[test]
+    fn clone_short_pick_parses() {
+        let cli = Cli::try_parse_from(["tsk", "clone", "-i"]).expect("parse");
+        let Commands::Clone(args) = cli.command.expect("command") else {
+            panic!("expected clone command");
+        };
+        assert!(args.pick);
+        assert!(args.id.is_none());
+    }
+
+    #[test]
+    fn status_pick_parses() {
+        let cli = Cli::try_parse_from(["tsk", "status", "--pick"]).expect("parse");
+        let Commands::Status(args) = cli.command.expect("command") else {
+            panic!("expected status command");
+        };
+        assert!(args.pick);
+        assert!(args.id.is_none());
+        assert!(args.status.is_none());
+    }
+
+    #[test]
+    fn branch_pick_parses() {
+        let cli = Cli::try_parse_from(["tsk", "branch", "--pick"]).expect("parse");
+        let Commands::Branch(args) = cli.command.expect("command") else {
+            panic!("expected branch command");
+        };
+        assert!(args.pick);
+        assert!(args.id.is_none());
+    }
+
+    #[test]
+    fn branch_delete_and_pick_conflict() {
+        let err = Cli::try_parse_from(["tsk", "branch", "-d", "--pick"]).expect_err("conflict");
+        let rendered = err.to_string();
+        assert!(rendered.contains("--pick"));
+        assert!(rendered.contains("--delete"));
     }
 
     #[test]

--- a/src/commands/branch.rs
+++ b/src/commands/branch.rs
@@ -13,6 +13,8 @@ use crate::services::issue_service::generate_branch_slug;
 use crate::services::{id_resolution, project_detection};
 use crate::storage::{frontmatter, issue_store};
 
+pub(crate) use crate::services::id_resolution::{current_repo, cwd_utf8, find_issue_for_branch};
+
 pub async fn branch(paths: &AppPaths, args: BranchArgs) -> Result<(), RiptskError> {
     if args.delete || args.force_delete {
         return delete_branch(paths, args).await;
@@ -22,10 +24,13 @@ pub async fn branch(paths: &AppPaths, args: BranchArgs) -> Result<(), RiptskErro
 
 async fn create_branch(paths: &AppPaths, args: BranchArgs) -> Result<(), RiptskError> {
     paths.require_initialized()?;
-    let BranchArgs { scope, id, .. } = args;
+    let BranchArgs {
+        scope, id, pick, ..
+    } = args;
     let config = load_config(paths.config_path().as_std_path()).map_err(RiptskError::Other)?;
     let cwd = cwd_utf8();
-    let Some(id) = id_resolution::require_id(paths, &config, &cwd, id, &scope)? else {
+    let Some(id) = id_resolution::resolve_or_pick_id(paths, &config, &cwd, id, pick, &scope)?
+    else {
         return Ok(());
     };
     let slug = create_branch_for_issue(paths, &id).await?;
@@ -320,55 +325,4 @@ pub(crate) fn is_protected_branch(branch: &str) -> bool {
         branch,
         "main" | "master" | "develop" | "devel" | "dev" | "trunk"
     )
-}
-
-pub(crate) fn current_repo() -> Result<std::path::PathBuf, RiptskError> {
-    std::env::current_dir().map_err(RiptskError::from)
-}
-
-pub(crate) fn cwd_utf8() -> camino::Utf8PathBuf {
-    camino::Utf8PathBuf::from(
-        std::env::current_dir()
-            .unwrap_or_default()
-            .to_string_lossy()
-            .to_string(),
-    )
-}
-
-pub(crate) fn find_issue_for_branch(
-    paths: &AppPaths,
-    branch: &str,
-) -> Result<camino::Utf8PathBuf, RiptskError> {
-    for path in issue_store::list_issues(paths)? {
-        match frontmatter::try_load_issue(path.as_std_path()) {
-            frontmatter::IssueLoadResult::Ok(issue) => {
-                if issue.frontmatter.branch.as_deref() == Some(branch)
-                    || issue.frontmatter.id_slug.as_deref() == Some(branch)
-                {
-                    return Ok(path);
-                }
-            }
-            frontmatter::IssueLoadResult::Conflict { id, .. } => {
-                for backup in [
-                    issue_store::local_backup_path(paths, &id),
-                    issue_store::remote_backup_path(paths, &id),
-                ] {
-                    if !backup.exists() {
-                        continue;
-                    }
-                    if let frontmatter::IssueLoadResult::Ok(issue) =
-                        frontmatter::try_load_issue(backup.as_std_path())
-                        && (issue.frontmatter.branch.as_deref() == Some(branch)
-                            || issue.frontmatter.id_slug.as_deref() == Some(branch))
-                    {
-                        return Ok(path.clone());
-                    }
-                }
-            }
-            frontmatter::IssueLoadResult::Err(error) => return Err(RiptskError::Other(error)),
-        }
-    }
-    Err(RiptskError::NotFound(format!(
-        "no issue found for branch {branch}"
-    )))
 }

--- a/src/commands/clone_cmd.rs
+++ b/src/commands/clone_cmd.rs
@@ -18,7 +18,9 @@ pub async fn run(paths: &AppPaths, args: CloneArgs) -> Result<(), RiptskError> {
     paths.require_initialized()?;
     let config = load_config(paths.config_path().as_std_path()).map_err(RiptskError::Other)?;
     let cwd = cwd_utf8();
-    let Some(id) = id_resolution::require_id(paths, &config, &cwd, args.id, &args.scope)? else {
+    let Some(id) =
+        id_resolution::resolve_or_pick_id(paths, &config, &cwd, args.id, args.pick, &args.scope)?
+    else {
         return Ok(());
     };
 

--- a/src/commands/done.rs
+++ b/src/commands/done.rs
@@ -1,9 +1,7 @@
 use crate::adapters::git::{CliGit, GitBackend};
 use crate::adapters::prompts::DialoguerPrompts;
 use crate::cli::{DoneArgs, SyncArgs};
-use crate::commands::branch::{
-    backend_issue_number, current_repo, cwd_utf8, find_issue_for_branch,
-};
+use crate::commands::branch::{backend_issue_number, current_repo, cwd_utf8};
 use crate::commands::{pr, sync_cmd};
 use crate::config::load_config;
 use crate::domain::issue::IssueState;
@@ -23,22 +21,16 @@ pub async fn run(paths: &AppPaths, args: DoneArgs) -> Result<(), RiptskError> {
     paths.require_initialized()?;
     let config = load_config(paths.config_path().as_std_path()).map_err(RiptskError::Other)?;
     let cwd = cwd_utf8();
-    let id = if let Some(input) = args.id.clone() {
-        id_resolution::resolve_id(paths, &config, &cwd, &input)?
-    } else {
-        match current_repo()
-            .and_then(|repo| CliGit::new().current_branch(repo.as_path()))
-            .and_then(|branch| find_issue_for_branch(paths, &branch))
-            .and_then(|path| {
-                let id = path.file_stem().unwrap_or_default().to_string();
-                crate::commands::issues::load_issue_or_conflict_error(path.as_std_path(), &id)
-            }) {
-            Ok(issue) => issue.frontmatter.id,
-            Err(_) => match id_resolution::require_id(paths, &config, &cwd, None, &args.scope)? {
-                Some(id) => id,
-                None => return Ok(()),
-            },
-        }
+    let id = match id_resolution::resolve_or_pick_id(
+        paths,
+        &config,
+        &cwd,
+        args.id.clone(),
+        args.pick,
+        &args.scope,
+    )? {
+        Some(id) => id,
+        None => return Ok(()),
     };
     let issue_path = issue_store::find_issue(paths, &id)?;
     let issue =

--- a/src/commands/issues.rs
+++ b/src/commands/issues.rs
@@ -5,7 +5,7 @@ use crate::adapters::picker::{
 };
 use crate::adapters::prompts::{DialoguerPrompts, PromptBackend};
 use crate::cli::{IdArgs, LsArgs, NewArgs, StatusArgs};
-use crate::config::load_config;
+use crate::config::{load_config, parse_state};
 use crate::domain::issue::{
     GithubIssueMeta, GitlabIssueMeta, IssueDocument, IssueFrontmatter, IssueState, JiraIssueMeta,
     Priority,
@@ -27,7 +27,7 @@ use std::io::IsTerminal;
 
 pub fn show(paths: &AppPaths, args: IdArgs) -> Result<(), RiptskError> {
     paths.require_initialized()?;
-    let IdArgs { scope, id } = args;
+    let IdArgs { scope, id, pick } = args;
     let config = load_config(paths.config_path().as_std_path()).map_err(RiptskError::Other)?;
     let cwd = camino::Utf8PathBuf::from(
         std::env::current_dir()
@@ -35,7 +35,8 @@ pub fn show(paths: &AppPaths, args: IdArgs) -> Result<(), RiptskError> {
             .to_string_lossy()
             .to_string(),
     );
-    let Some(id) = id_resolution::require_id(paths, &config, &cwd, id, &scope)? else {
+    let Some(id) = id_resolution::resolve_or_pick_id(paths, &config, &cwd, id, pick, &scope)?
+    else {
         return Ok(());
     };
     let path = issue_store::find_issue(paths, &id)?;
@@ -51,7 +52,7 @@ pub fn show(paths: &AppPaths, args: IdArgs) -> Result<(), RiptskError> {
 
 pub fn path(paths: &AppPaths, args: IdArgs) -> Result<(), RiptskError> {
     paths.require_initialized()?;
-    let IdArgs { scope, id } = args;
+    let IdArgs { scope, id, pick } = args;
     let config = load_config(paths.config_path().as_std_path()).map_err(RiptskError::Other)?;
     let cwd = camino::Utf8PathBuf::from(
         std::env::current_dir()
@@ -59,7 +60,8 @@ pub fn path(paths: &AppPaths, args: IdArgs) -> Result<(), RiptskError> {
             .to_string_lossy()
             .to_string(),
     );
-    let Some(id) = id_resolution::require_id(paths, &config, &cwd, id, &scope)? else {
+    let Some(id) = id_resolution::resolve_or_pick_id(paths, &config, &cwd, id, pick, &scope)?
+    else {
         return Ok(());
     };
     println!("{}", issue_store::find_issue(paths, &id)?);
@@ -483,7 +485,7 @@ fn style_with_color(text: String, color: Color) -> console::StyledObject<String>
 
 pub fn edit(paths: &AppPaths, args: IdArgs) -> Result<(), RiptskError> {
     paths.require_initialized()?;
-    let IdArgs { scope, id } = args;
+    let IdArgs { scope, id, pick } = args;
     let config = load_config(paths.config_path().as_std_path()).map_err(RiptskError::Other)?;
     let cwd = camino::Utf8PathBuf::from(
         std::env::current_dir()
@@ -491,7 +493,8 @@ pub fn edit(paths: &AppPaths, args: IdArgs) -> Result<(), RiptskError> {
             .to_string_lossy()
             .to_string(),
     );
-    let Some(id) = id_resolution::require_id(paths, &config, &cwd, id, &scope)? else {
+    let Some(id) = id_resolution::resolve_or_pick_id(paths, &config, &cwd, id, pick, &scope)?
+    else {
         return Ok(());
     };
     let path = issue_store::find_issue(paths, &id)?;
@@ -518,7 +521,12 @@ pub fn edit(paths: &AppPaths, args: IdArgs) -> Result<(), RiptskError> {
 
 pub fn set_status(paths: &AppPaths, args: StatusArgs) -> Result<(), RiptskError> {
     paths.require_initialized()?;
-    let StatusArgs { scope, id, status } = args;
+    let StatusArgs {
+        scope,
+        id,
+        status,
+        pick,
+    } = args;
     let config = load_config(paths.config_path().as_std_path()).map_err(RiptskError::Other)?;
     let cwd = camino::Utf8PathBuf::from(
         std::env::current_dir()
@@ -526,7 +534,13 @@ pub fn set_status(paths: &AppPaths, args: StatusArgs) -> Result<(), RiptskError>
             .to_string_lossy()
             .to_string(),
     );
-    let Some(id) = id_resolution::require_id(paths, &config, &cwd, id, &scope)? else {
+    let (id, status) = if status.is_none() && id.as_ref().is_some_and(|v| parse_state(v).is_ok()) {
+        (None, id)
+    } else {
+        (id, status)
+    };
+    let Some(id) = id_resolution::resolve_or_pick_id(paths, &config, &cwd, id, pick, &scope)?
+    else {
         return Ok(());
     };
     let status = status.ok_or_else(|| RiptskError::General("<status> required".into()))?;
@@ -549,6 +563,7 @@ pub fn close(paths: &AppPaths, args: IdArgs) -> Result<(), RiptskError> {
         paths,
         StatusArgs {
             scope: args.scope,
+            pick: args.pick,
             id: args.id,
             status: Some("done".into()),
         },
@@ -561,6 +576,7 @@ pub fn reopen(paths: &AppPaths, args: IdArgs) -> Result<(), RiptskError> {
         paths,
         StatusArgs {
             scope: args.scope,
+            pick: args.pick,
             id: args.id,
             status: Some("todo".into()),
         },
@@ -569,7 +585,7 @@ pub fn reopen(paths: &AppPaths, args: IdArgs) -> Result<(), RiptskError> {
 
 pub fn remove(paths: &AppPaths, args: IdArgs) -> Result<(), RiptskError> {
     paths.require_initialized()?;
-    let IdArgs { scope, id } = args;
+    let IdArgs { scope, id, pick } = args;
     let config = load_config(paths.config_path().as_std_path()).map_err(RiptskError::Other)?;
     let cwd = camino::Utf8PathBuf::from(
         std::env::current_dir()
@@ -577,7 +593,8 @@ pub fn remove(paths: &AppPaths, args: IdArgs) -> Result<(), RiptskError> {
             .to_string_lossy()
             .to_string(),
     );
-    let Some(id) = id_resolution::require_id(paths, &config, &cwd, id, &scope)? else {
+    let Some(id) = id_resolution::resolve_or_pick_id(paths, &config, &cwd, id, pick, &scope)?
+    else {
         return Ok(());
     };
     let path = issue_store::find_issue(paths, &id)?;

--- a/src/commands/views.rs
+++ b/src/commands/views.rs
@@ -240,7 +240,9 @@ fn shift(paths: &AppPaths, args: IdArgs, direction: ShiftDirection) -> Result<()
             .to_string(),
     );
     let service = IssueService::new(paths, &config);
-    let Some(id) = id_resolution::require_id(paths, &config, &cwd, args.id, &args.scope)? else {
+    let Some(id) =
+        id_resolution::resolve_or_pick_id(paths, &config, &cwd, args.id, args.pick, &args.scope)?
+    else {
         return Ok(());
     };
     service.shift_issue_order(&id, direction)

--- a/src/services/id_resolution.rs
+++ b/src/services/id_resolution.rs
@@ -1,9 +1,11 @@
+use crate::adapters::git::{CliGit, GitBackend};
 use crate::adapters::picker::{FzfPicker, IssueDisplayMode, Picker, format_issue_plain};
 use crate::cli::{LsArgs, ScopeArgs};
 use crate::config::Config;
 use crate::error::{RiptskError, StoreError};
 use crate::paths::AppPaths;
 use crate::services::{issue_ids, issue_service::IssueService, project_detection};
+use crate::storage::{frontmatter, issue_store};
 use camino::Utf8Path;
 
 pub fn resolve_id(
@@ -97,6 +99,85 @@ pub fn require_id(
             Err(e)
         }
     }
+}
+
+pub fn resolve_or_pick_id(
+    paths: &AppPaths,
+    config: &Config,
+    cwd: &Utf8Path,
+    id: Option<String>,
+    pick: bool,
+    scope_args: &ScopeArgs,
+) -> Result<Option<String>, RiptskError> {
+    if let Some(input) = id {
+        return resolve_id(paths, config, cwd, &input).map(Some);
+    }
+
+    if pick {
+        return require_id(paths, config, cwd, None, scope_args);
+    }
+
+    match current_repo()
+        .and_then(|repo| CliGit::new().current_branch(repo.as_path()))
+        .and_then(|branch| find_issue_for_branch(paths, &branch))
+        .and_then(|path| {
+            let id = path.file_stem().unwrap_or_default().to_string();
+            crate::commands::issues::load_issue_or_conflict_error(path.as_std_path(), &id)
+        }) {
+        Ok(issue) => Ok(Some(issue.frontmatter.id)),
+        Err(_) => require_id(paths, config, cwd, None, scope_args),
+    }
+}
+
+pub(crate) fn current_repo() -> Result<std::path::PathBuf, RiptskError> {
+    std::env::current_dir().map_err(RiptskError::from)
+}
+
+pub(crate) fn cwd_utf8() -> camino::Utf8PathBuf {
+    camino::Utf8PathBuf::from(
+        std::env::current_dir()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string(),
+    )
+}
+
+pub(crate) fn find_issue_for_branch(
+    paths: &AppPaths,
+    branch: &str,
+) -> Result<camino::Utf8PathBuf, RiptskError> {
+    for path in issue_store::list_issues(paths)? {
+        match frontmatter::try_load_issue(path.as_std_path()) {
+            frontmatter::IssueLoadResult::Ok(issue) => {
+                if issue.frontmatter.branch.as_deref() == Some(branch)
+                    || issue.frontmatter.id_slug.as_deref() == Some(branch)
+                {
+                    return Ok(path);
+                }
+            }
+            frontmatter::IssueLoadResult::Conflict { id, .. } => {
+                for backup in [
+                    issue_store::local_backup_path(paths, &id),
+                    issue_store::remote_backup_path(paths, &id),
+                ] {
+                    if !backup.exists() {
+                        continue;
+                    }
+                    if let frontmatter::IssueLoadResult::Ok(issue) =
+                        frontmatter::try_load_issue(backup.as_std_path())
+                        && (issue.frontmatter.branch.as_deref() == Some(branch)
+                            || issue.frontmatter.id_slug.as_deref() == Some(branch))
+                    {
+                        return Ok(path.clone());
+                    }
+                }
+            }
+            frontmatter::IssueLoadResult::Err(error) => return Err(RiptskError::Other(error)),
+        }
+    }
+    Err(RiptskError::NotFound(format!(
+        "no issue found for branch {branch}"
+    )))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #45

## Summary

This PR implements auto-selection of tasks from the active git branch when running commands without an explicit task ID. When a branch is associated with a task (via its name or id_slug), commands like `tsk edit`, `tsk show`, etc. will now automatically select that task instead of opening an interactive picker. A new `--pick` / `-i` flag is added to force interactive selection when needed.

## Key Changes

- **Auto-select from branch**: Implemented task resolution that automatically detects the current branch and selects the associated task without requiring manual ID input
- **New `--pick` flag**: Added `--pick` / `-i` flag across multiple commands (`show`, `edit`, `done`, `clone`, `status`, `branch`) to explicitly request interactive task selection, bypassing auto-detection
- **Service refactoring**: Moved id-resolution helper functions (`current_repo`, `cwd_utf8`, `find_issue_for_branch`) from `branch.rs` to the `id_resolution` module for better code organization and reusability
- **Updated ID resolution logic**: Replaced `require_id` with `resolve_or_pick_id` function that handles both automatic branch-based selection and manual interactive picking
- **Comprehensive test coverage**: Added 8 new tests covering:
  - `--pick` flag parsing for multiple commands (show, edit, done, clone, status, branch)
  - Conflict detection between `--pick` and mutually exclusive flags like `--delete`