### PR TITLE
Solves issue "#136 Standardize terminology: introduce RepoProject as canonical concept"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,29 @@
 
 This project is pre-1.0.0. There is NO backward compatibility requirement. Breaking changes are allowed and expected — do not add migration paths, compatibility shims, or legacy support for old formats.
 
+## Terminology
+
+The terms in this glossary have single meanings — do not introduce ambiguous synonyms. Use the `code identifier` column in Rust source and the `YAML / doc form` column elsewhere.
+
+| Concept | Code identifier | YAML / doc form | Meaning |
+|---|---|---|---|
+| **RepoProject** | `RepoProject` (struct), `repo_project` (vars) | `project` (generic), `repo_project` when precision needed | The coding project — a git repo (or a local non-git directory). The unit the user works on. What GitHub/GitLab call a "project" or "repo". |
+| **VCBackend** | `VCBackendSpec` (struct), `vc_backend` (field/vars) | `vc_backend` | Version control nature: GitHub, GitLab, or Local. Provides branches, PRs/MRs, CI. The `kind` field is a `BackendKind`. |
+| **TasksBackend** | `TasksBackendSpec` (struct), `tasks_backend` (field/vars) | `tasks_backend` | Issue tracking nature: GitHub, GitLab, Jira, or Local. Provides issues/tasks CRUD. The `kind` field is a `BackendKind`. |
+| **BackendKind** | `BackendKind` (enum) | `type` (YAML key within `vc_backend` / `tasks_backend`) | The provider-identity enum shared by both backend specs: `Github`, `Gitlab`, `Jira`, `Local`. Replaces the pre-refactor `Backend` enum. |
+| **RepoProject label** | `repo_project_label` | `repo_project_label` (preferred) or `project_label` | String used to partition a shared Jira project by RepoProject. Always carries the fixed `proj::` prefix (e.g. `proj::my-api`) so the Jira label unambiguously identifies a RepoProject reference. Injected into Jira labels on push; filtered on pull. |
+| **RepoProject key** | `repo_project_key` (new synonym) / `key` | `key` | Short ID prefix (e.g. `RIPTSK` in `RIPTSK--123`). One per RepoProject. `BackendConfig.key` is renamed into the RepoProject.) |
+| **JiraProject** | `JiraProject`, `jira_project` | `jira_project` | The external Jira container (e.g. `PROJ`). Stored as `"org/PROJ"`. Replaces the `repo:` field when a TasksBackend is of type Jira. |
+| **Backend** (plain) | — | — | **Banned** as a standalone term for a project-level concept. Use "VCBackend" (`VCBackendSpec`) or "TasksBackend" (`TasksBackendSpec`) explicitly. The pre-refactor `Backend` provider-identity enum has been renamed to `BackendKind`. |
+
+Rules:
+
+- The word "project" in code or docs, unqualified, always means RepoProject.
+- "Jira project" (two words) is always the external Jira concept; never abbreviated to "project" alone.
+- `BackendConfig` is replaced entirely by `RepoProject` (plus inline `VCBackendSpec` and `TasksBackendSpec`).
+- The `--project` / `-p` CLI flag keeps its name; it now literally selects a RepoProject by name (no change in behavior — just cleanly matches the terminology).
+- `IssueFrontmatter.project: String` keeps its name; it stores `RepoProject.name`.
+
 ## Pre-commit configs
 
 - `.pre-commit-config.yaml` — active repository config

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ flowchart LR
     User[User terminal] --> CLI[tsk CLI]
     CLI --> Repo[RIPTSK_REPO<br/>issues, templates, riptsk.yaml, .git]
     CLI --> Cache[XDG_CACHE_HOME riptsk<br/>views, id_map, backend_state, session]
-    CLI --> ProjRepo[Project repo<br/>registered backend cwd]
+    CLI --> ProjRepo[Project repo<br/>registered RepoProject cwd]
     CLI --> Sync[Sync engine]
     Sync --> GitHub[GitHub]
     Sync --> GitLab[GitLab]
@@ -470,10 +470,15 @@ defaults:
   assignee: null
   template: task
 
-backends:
+projects:
   - name: my-github
-    type: github
-    repo: myorg/my-app
+    vc_backend:
+      type: github
+      repo: myorg/my-app
+      path: /home/user/src/my-app
+    tasks_backend:
+      type: github
+      repo: myorg/my-app
     default_board: personal
 
 boards:
@@ -520,10 +525,12 @@ Exactly these keys are supported:
 
 Everything else is YAML-only, including:
 
-- `backends`
+- `projects`
 - `boards`
 - `recurring`
 - `ai.features.*`
+
+Shared Jira project setup, including `repo_project_label` partitioning, is documented in [docs/workflow/jira-gitlab-setup.md](docs/workflow/jira-gitlab-setup.md).
 
 ## Issue format
 

--- a/docs/spec/01-problem-statement.md
+++ b/docs/spec/01-problem-statement.md
@@ -2,21 +2,21 @@
 
 Status: active (permanent)
 
-A software engineer working across multiple personal + work projects, that can be (self-hosted or not):
+A software engineer working across multiple personal + work RepoProjects, that can be (self-hosted or not):
 
-- GitLab projects
-- GitHub projects
-- Non-GitHub/GitLab projects (e.g. Codeberg, Gitea, gitolite, etc)
+- GitLab RepoProjects
+- GitHub RepoProjects
+- Non-GitHub/GitLab RepoProjects (e.g. Codeberg, Gitea, gitolite, etc)
 
-Has no centralized way to manage all their issues. Each platform has its own UI, its own kanban, its own project context. Switching between them to get an overview of all work in flight is friction-heavy and browser-dependent.
+Has no centralized way to manage all their issues. Each platform has its own UI, its own kanban, its own RepoProject context. Switching between them to get an overview of all work in flight is friction-heavy and browser-dependent.
 
 **The need:**
 
-- A single pane of glass for all issues across all projects and platforms
+- A single pane of glass for all issues across all RepoProjects and platforms
 - A kanban board view, browsable with standard Unix tools
 - Full offline capability — no browser, no network required to read/manage issues
 - Bidirectional sync: changes made locally reflect on remote; changes on remote pull down locally
-- Support for local-only tasks not associated with any remote project
+- Support for local-only tasks not associated with any remote RepoProject
 - Works naturally in a terminal-centric, editor-first workflow (Neovim, kitty, bash)
 
 **What this is not:**

--- a/docs/spec/02-philosophy-design-principles.md
+++ b/docs/spec/02-philosophy-design-principles.md
@@ -12,7 +12,7 @@ Version history, audit trail, and backup are handled entirely by git. No additio
 
 ### 2.3 Views are derived, never stored
 
-Kanban boards, project views, org views, cycle views — all are generated at runtime by reading issue frontmatter. They are never the source of truth. The `views/` directory lives in the cache (`$XDG_CACHE_HOME/riptsk/views/`), outside the repo, and is always regeneratable from scratch.
+Kanban boards, RepoProject views, org views, cycle views — all are generated at runtime by reading issue frontmatter. They are never the source of truth. The `views/` directory lives in the cache (`$XDG_CACHE_HOME/riptsk/views/`), outside the repo, and is always regeneratable from scratch.
 
 ### 2.4 One source of truth per concern
 
@@ -24,14 +24,14 @@ Direct file manipulation is always possible, but the CLI is the primary write in
 
 ### 2.6 Remote IDs win (when a remote exists)
 
-For GitHub and GitLab projects, the remote is the source of truth for issue identity. Local IDs are provisional until a first push assigns a real remote ID. After that, the remote ID is permanent.
+For GitHub and GitLab RepoProjects, the remote is the source of truth for issue identity. Local IDs are provisional until a first push assigns a real remote ID. After that, the remote ID is permanent.
 
-For projects with non-GitHub/GitLab remotes or no remote at all, there is no remote source of truth. IDs are assigned locally using the project prefix (e.g. `ICE-001`) and are permanent from creation — they are never provisional.
+For RepoProjects with non-GitHub/GitLab remotes or no remote at all, there is no remote source of truth. IDs are assigned locally using the RepoProject key prefix (e.g. `ICE-001`) and are permanent from creation — they are never provisional.
 
 ### 2.7 Mirror glab/gh behavior
 
-`tsk` is context-aware: commands run from inside a project repo automatically scope to that project, exactly as `glab` and `gh` do. You never need to specify which project you're operating on — your current directory provides that context.
+`tsk` is context-aware: commands run from inside a RepoProject repo automatically scope to that RepoProject, exactly as `glab` and `gh` do. You never need to specify which RepoProject you're operating on — your current directory provides that context.
 
 ### 2.8 Opt-in complexity
 
-Start with the simplest thing that works. Every advanced feature (AI, recurring tasks, cycles, orgs) is additive and optional. The core — create issue, move it, sync it — must always work with zero config beyond project registration.
+Start with the simplest thing that works. Every advanced feature (AI, recurring tasks, cycles, orgs) is additive and optional. The core — create issue, move it, sync it — must always work with zero config beyond RepoProject registration.

--- a/docs/spec/03-design-decisions.md
+++ b/docs/spec/03-design-decisions.md
@@ -87,3 +87,13 @@ Lifecycle commands (`new`, `close`, `status`, `reopen`, `rm`) auto-commit `$RIPT
 **Commit message format:** `riptsk: <verb> <ID> — <title>` (see [15 — Version Control & Backup](archive/15-version-control-backup.md) for full conventions).
 
 Auto-commit does not auto-push. It goes through normal `git commit`, so the pre-commit hook ([25 — RIPTSK_REPO Hooks](archive/25-tsk-repo-hooks.md)) runs and validates the commit automatically.
+
+### 3.10 Terminology: RepoProject, VCBackend, TasksBackend
+
+`CLAUDE.md` is the canonical glossary for project-level terminology. Code, comments, specs, docs, tests, and CLI help should use those meanings consistently.
+
+`RepoProject` exists because "project" was overloaded across the registered working unit, the issue ID key prefix, and the external Jira container. The explicit name removes that ambiguity and reserves unqualified "project" for the user-facing working unit only.
+
+The split into `VCBackend` and `TasksBackend` reflects actual capability boundaries. GitHub and GitLab naturally provide both. Jira is issue-only, and Local is a special-case offline provider. Encoding both natures inline on the RepoProject is clearer than the old `vc:` indirection because the config states each responsibility directly.
+
+`JiraProject` is always the external Jira container and is never shortened to plain "project". That keeps Jira vocabulary pinned to its Jira-scoped meaning and prevents it from colliding with RepoProject.

--- a/docs/spec/19-non-goals.md
+++ b/docs/spec/19-non-goals.md
@@ -6,7 +6,7 @@ These are explicitly out of scope and will not be implemented:
 
 - **TUI kanban** — the filesystem view (`tree`, `ls`, nvim/yazi) is sufficient
 - **Background sync daemon** — sync is always explicit and user-triggered
-- **Team collaboration tooling** — designed for a single engineer across multiple machines, but usable by a small team with a simple convention: each developer works on one task at a time (task-per-dev partitioning). Conflicts are detected and preserved for manual resolution (see [03 — Design Decisions §3.5](03-design-decisions.md)). What `riptsk` will *not* build: shared dashboards, team notifications, access control, or real-time co-editing. Multi-host sync is supported via `tsk session` and `$RIPTSK_REPO` git (see [11 — Multi-Host Workflow](archive/11-multi-host-workflow.md))
+- **Team collaboration tooling** — designed for a single engineer across multiple machines, but usable by a small team with a simple convention: each developer works on one task at a time within a RepoProject. Conflicts are detected and preserved for manual resolution (see [03 — Design Decisions §3.5](03-design-decisions.md)). What `riptsk` will *not* build: shared dashboards, team notifications, access control, or real-time co-editing. Multi-host sync is supported via `tsk session` and `$RIPTSK_REPO` git (see [11 — Multi-Host Workflow](archive/11-multi-host-workflow.md))
 - **Three-way merge for conflicts** — conflicts are detected and preserved for manual resolution (see [03 — Design Decisions §3.5](03-design-decisions.md)), but `riptsk` does not attempt automatic three-way merging of frontmatter or body content
 - **Web interface** — not needed, contradicts the philosophy
 - **Database** — flat files + optional JSON cache is sufficient

--- a/docs/spec/20-open-questions.md
+++ b/docs/spec/20-open-questions.md
@@ -11,7 +11,7 @@ When `LOCAL-3f2a` → `WHL-043`, scan all `$RIPTSK_REPO/issues/*.md` for referen
 If an issue is deleted or transferred on the remote, do not silently remove the local file. Set `remote_deleted: true` in frontmatter, preserve the last known local `state`, and emit a warning. The user decides what to do with it.
 
 **[RESOLVED] Self-hosted GitLab.**
-Pass `host:` from `riptsk.yaml` remote entry to `glab` via `GITLAB_HOST` env variable or `--hostname` flag. Document the glab authentication setup for self-hosted instances.
+Pass `host:` from the RepoProject's GitLab backend entry to `glab` via `GITLAB_HOST` env variable or `--hostname` flag. Document the glab authentication setup for self-hosted instances.
 
 **[RESOLVED] Multiple remotes, same numeric ID.**
 Remote state cache key is always `<type>:<repo>:<issue_id>` — never just the numeric ID. `WHL-042` and `FSH-042` can coexist.

--- a/docs/workflow/README.md
+++ b/docs/workflow/README.md
@@ -7,8 +7,8 @@ Central index for riptsk workflow documentation — both using riptsk in your ow
 | Document | Summary |
 |----------|---------|
 | [Branch → PR → Done](branch-pr-done.md) | The main remote workflow: `tsk branch`, `tsk pr`, `tsk done`, `tsk start` |
-| [Backend Sync](backend-sync.md) | Credentials, `riptsk.yaml` backend config, `tsk sync`, conflict resolution |
-| [Jira + GitLab Setup](jira-gitlab-setup.md) | Step-by-step: Jira for issues, GitLab for branches and MRs (via `vc:`) |
+| [Backend Sync](backend-sync.md) | Credentials, `riptsk.yaml` `projects:` config, `tsk sync`, conflict resolution |
+| [Jira + GitLab Setup](jira-gitlab-setup.md) | Step-by-step: Jira TasksBackend + GitLab VCBackend, including shared Jira `repo_project_label` partitioning |
 
 ## Contributing to riptsk
 

--- a/docs/workflow/backend-sync.md
+++ b/docs/workflow/backend-sync.md
@@ -1,6 +1,6 @@
 # Sync with GitHub, GitLab, Jira
 
-Backends are configured in `riptsk.yaml` under `backends`.
+RepoProjects are configured in `riptsk.yaml` under `projects:`.
 
 Sync data flow:
 
@@ -63,43 +63,68 @@ Detection rules:
 - local git repo with no supported remote -> `local`
 - non-git directory -> `local`
 
-Jira is not auto-detected from git remotes. Add Jira backends manually in `riptsk.yaml`.
+Jira TasksBackends are not auto-detected from git remotes. Add Jira-backed RepoProjects manually in `riptsk.yaml`.
 
 `tsk` also performs best-effort project auto-registration on startup when the current directory is not already registered.
 
-## Manual backend configuration
+## Manual RepoProject configuration
 
 ```yaml
-backends:
+projects:
   - name: my-github
-    type: github
-    repo: myorg/my-app
+    vc_backend:
+      type: github
+      repo: myorg/my-app
+      path: /home/user/src/my-app
+    tasks_backend:
+      type: github
+      repo: myorg/my-app
 
   - name: my-gitlab
-    type: gitlab
-    host: https://gitlab.internal.example
-    repo: team/my-app
+    vc_backend:
+      type: gitlab
+      host: https://gitlab.internal.example
+      repo: team/my-app
+      path: /home/user/src/my-app
+    tasks_backend:
+      type: gitlab
+      host: https://gitlab.internal.example
+      repo: team/my-app
 
   - name: my-jira
-    type: jira
-    host: https://myteam.atlassian.net
-    repo: myorg/PROJ
-    default_issue_type: Task
-    vc: my-github
+    vc_backend:
+      type: gitlab
+      host: https://gitlab.internal.example
+      repo: team/my-app
+      path: /home/user/src/my-app
+    tasks_backend:
+      type: jira
+      host: https://myteam.atlassian.net
+      jira_project: myorg/PROJ
+      default_issue_type: Task
+    repo_project_label: proj::my-app
 
   - name: side-project
-    type: local
-    path: /home/user/projects/side-project
+    vc_backend:
+      type: local
+      path: /home/user/projects/side-project
+    tasks_backend:
+      type: local
+      path: /home/user/projects/side-project
 ```
 
 Field notes:
 
-- `type` is one of `github`, `gitlab`, `jira`, `local`
-- `repo` format is `owner repo` style by backend convention:
-  GitHub uses `owner/repo`, GitLab uses `group/project`, Jira uses `org/PROJECT_KEY`
-- Jira `host` is required and must start with `https://`
-- Jira `vc` may point to a GitHub or GitLab backend for branch and PR commands
-- `path` is used for local path-based project detection
+- `name` is the RepoProject name used by `-p/--project`.
+- `vc_backend.type` is `github`, `gitlab`, or `local`. `jira` is never valid here.
+- `tasks_backend.type` is `github`, `gitlab`, `jira`, or `local`.
+- `vc_backend.repo` uses `owner/repo` for GitHub and `group/project` for GitLab.
+- `tasks_backend.repo` uses the same remote format for GitHub and GitLab.
+- `tasks_backend.jira_project` uses `org/PROJECT_KEY`.
+- Jira `tasks_backend.host` is required and must start with `https://`.
+- `repo_project_label` is optional and Jira-only. When set, riptsk adds that label on push, filters by it on pull (`labels = "<label>"`), and strips it from local issue labels after pull. Labels always carry the fixed `proj::` prefix (e.g. `proj::my-app`) so the Jira label unambiguously identifies a RepoProject reference.
+- `repo_project_label` auto-derivation order is: git origin tail, then cwd basename. The suffix is sanitized to lowercase, separators become `-`, invalid characters are dropped, duplicates collapse; the final label is the prefix + non-empty suffix, must contain no whitespace or `"`, and be at most 255 bytes. On `tsk register --repo-project-label <value>` the prefix may be omitted — riptsk normalizes the input to the prefixed form.
+- `path` is used for path-based RepoProject detection. riptsk checks `vc_backend.path` first, then `tasks_backend.path`.
 
 ## Sync commands
 
@@ -117,13 +142,12 @@ tsk sync resolve <ID> --take-remote
 
 `tsk sync` without a subcommand runs pull, then push.
 
-Project selection can be scoped with the standard project flags where supported:
+RepoProject selection can be scoped with the standard project flags where supported:
 
 ```bash
 tsk sync -p my-github
-tsk sync --backend my-gitlab
-tsk done -p my-github <ID>
-tsk done -a <ID>
+tsk sync pull -p my-jira
+tsk sync push -a
 ```
 
 ## Conflict resolution
@@ -150,5 +174,5 @@ tsk sync resolve <ID> --take-remote
 
 ## Related
 
-- [Branch → PR → Done](branch-pr-done.md) — the remote workflow that consumes these backends
-- [Jira + GitLab Setup](jira-gitlab-setup.md) — step-by-step for the Jira+GitLab pattern
+- [Branch → PR → Done](branch-pr-done.md) — the remote workflow that consumes these RepoProjects
+- [Jira + GitLab Setup](jira-gitlab-setup.md) — step-by-step for Jira TasksBackend + GitLab VCBackend, including shared Jira partitioning

--- a/docs/workflow/branch-pr-done.md
+++ b/docs/workflow/branch-pr-done.md
@@ -1,6 +1,6 @@
 # Branch → PR → Done
 
-The main remote workflow for turning an issue into merged code. Works with GitHub, GitLab, or Jira-backed issues that delegate version control via `vc:`.
+The main remote workflow for turning an issue into merged code. Works with GitHub, GitLab, or Jira-backed issues that use a non-local VCBackend for branch and PR operations.
 
 ```bash
 tsk new --title "Fix login bug"
@@ -90,7 +90,7 @@ When a version-control backend is available and the issue has a branch, `tsk don
 7. syncs the issue back to its backend
 8. regenerates cached views
 
-When the issue is local-only or Jira-without-`vc`, `tsk done` skips PR merge, marks the issue `done`, syncs issue state if applicable, and regenerates views.
+When the issue is local-only or the RepoProject has a Jira TasksBackend plus a local VCBackend, `tsk done` skips PR merge, marks the issue `done`, syncs issue state if applicable, and regenerates views.
 
 Manual equivalent:
 

--- a/docs/workflow/jira-gitlab-setup.md
+++ b/docs/workflow/jira-gitlab-setup.md
@@ -1,14 +1,14 @@
 # Setup: Jira (issues) + GitLab (vc)
 
-Step-by-step guide to configure a riptsk project where **Jira** tracks issues and **GitLab** hosts branches, merge requests, and CI.
+Step-by-step guide to configure a riptsk RepoProject where **Jira** is the TasksBackend and **GitLab** is the VCBackend for branches, merge requests, and CI.
 
 This is the common enterprise pattern: code review lives on GitLab, but ticketing, planning, and reporting live on Jira. Every branch and MR title carries a Jira key (e.g. `PROJ-123`) so Jira's Development panel auto-populates.
 
 ## Prerequisites
 
 - `tsk` installed — see [Installation](../../README.md#installation).
-- A GitLab project you can push to (self-hosted or gitlab.com).
-- A Jira Cloud or Server/DC instance with a project key (e.g. `PROJ`) and permission to create and transition issues.
+- A GitLab RepoProject you can push to (self-hosted or gitlab.com).
+- A Jira Cloud or Server/DC instance with a Jira project key (e.g. `PROJ`) and permission to create and transition issues.
 - Git remote for the project already pointing at the GitLab repo.
 
 ## 1. Generate credentials
@@ -60,7 +60,7 @@ tsk init
 
 This creates `$RIPTSK_REPO` (defaults to `$XDG_DATA_HOME/riptsk`) with `issues/`, `templates/`, `riptsk.yaml`, and a git repo.
 
-## 4. Register the GitLab backend
+## 4. Register the GitLab RepoProject
 
 From the project directory (the one with the GitLab git remote):
 
@@ -69,63 +69,111 @@ cd /path/to/your/project
 tsk register
 ```
 
-`tsk register` detects the `gitlab` remote and adds an entry to `riptsk.yaml`. Confirm with:
+`tsk register` detects the `gitlab` remote and adds a RepoProject entry to `riptsk.yaml`. Confirm with:
 
 ```bash
 tsk register --list
 ```
 
-## 5. Add the Jira backend manually
+## 5. Configure the RepoProject
 
-Jira is **not** auto-detected from git remotes — it must be configured by hand. Open `riptsk.yaml`:
+Jira is not auto-detected from git remotes. The supported config shape is:
 
 ```bash
 tsk config edit   # or: $EDITOR "$RIPTSK_REPO/riptsk.yaml"
 ```
 
-Add a Jira backend that points its `vc` field at the GitLab backend you just registered:
-
 ```yaml
-backends:
-  - name: my-gitlab
-    type: gitlab
-    host: https://gitlab.com          # or your self-hosted host
-    repo: team/my-app                  # group/project
-
+projects:
   - name: my-jira
-    type: jira
-    host: https://mycompany.atlassian.net
-    repo: mycompany/PROJ               # org / PROJECT_KEY
-    default_issue_type: Task           # Task, Story, Bug, etc.
-    vc: my-gitlab                      # delegate branches and MRs here
+    vc_backend:
+      type: gitlab
+      host: https://gitlab.com
+      repo: team/my-app
+      path: /path/to/your/project
+    tasks_backend:
+      type: jira
+      host: https://mycompany.atlassian.net
+      jira_project: mycompany/PROJ
+      default_issue_type: Task
+    default_board: personal
+    repo_project_label: proj::my-app
 ```
 
 Field notes:
 
-- `host` is required for Jira and must start with `https://`.
-- `repo` for Jira is `org/PROJECT_KEY` — the key is what appears in issue IDs like `PROJ-123`.
+- `tasks_backend.host` is required for Jira and must start with `https://`.
+- `tasks_backend.jira_project` is `org/PROJECT_KEY`.
 - `default_issue_type` must match an issue type that exists in the Jira project. Check in Jira under **Project settings → Issue types**.
-- `vc: my-gitlab` is the critical line — without it, `tsk start`, `tsk branch`, and `tsk pr` will skip branch/MR creation for Jira issues.
+- The VCBackend/TasksBackend split is the critical concept. Without a non-local VCBackend, `tsk start`, `tsk branch`, and `tsk pr` skip branch/MR creation for Jira issues.
 
-## 6. Point the project directory at Jira
+## 6. Register the project directory
 
-`tsk register` bound the cwd to the GitLab backend. To make `tsk` use Jira for new issues from this project, re-register with an explicit backend:
+From the project directory:
 
 ```bash
-tsk register --backend my-jira
-tsk register --list
+cd /path/to/your/project
+tsk register
 ```
 
-The same directory can be registered against multiple backends; scope commands with `-p my-jira` / `-p my-gitlab` or use `--all` when needed.
+`tsk register` detects the GitLab remote, sets the RepoProject name, stores the local path, and derives `repo_project_label` from the origin URL tail by default — always as `proj::<sanitized-tail>`. To override that label during registration:
 
-## 7. Smoke test: create and sync
+```bash
+tsk register --repo-project-label platform-api
+# stored as proj::platform-api
+
+tsk register --repo-project-label proj::platform-api
+# same result — passing the prefix explicitly is accepted
+```
+
+`--project-label` is accepted as an alias. Labels stored in `riptsk.yaml` always carry the `proj::` prefix.
+
+## 7. Shared Jira project (label-partitioned)
+
+Multiple RepoProjects can share one Jira project when each RepoProject has a distinct `repo_project_label`.
+
+```yaml
+projects:
+  - name: billing-api
+    vc_backend: { type: gitlab, host: https://gitlab.com, repo: team/billing-api, path: /src/billing-api }
+    tasks_backend: { type: jira, host: https://jira.example.com, jira_project: company/PLAT, default_issue_type: Task }
+    repo_project_label: proj::billing-api
+
+  - name: auth-service
+    vc_backend: { type: gitlab, host: https://gitlab.com, repo: team/auth-service, path: /src/auth-service }
+    tasks_backend: { type: jira, host: https://jira.example.com, jira_project: company/PLAT, default_issue_type: Task }
+    repo_project_label: proj::auth-service
+
+  - name: web-console
+    vc_backend: { type: gitlab, host: https://gitlab.com, repo: team/web-console, path: /src/web-console }
+    tasks_backend: { type: jira, host: https://jira.example.com, jira_project: company/PLAT, default_issue_type: Task }
+    repo_project_label: proj::web-console
+```
+
+Typical flow:
+
+```bash
+cd /src/billing-api && tsk register
+cd /src/auth-service && tsk register
+cd /src/web-console && tsk register --repo-project-label frontend-console
+# stored as proj::frontend-console
+```
+
+Behavior:
+
+- Pull uses JQL `project = PLAT AND labels = "proj::<suffix>"`.
+- Push injects `repo_project_label` (e.g. `proj::billing-api`) into Jira labels.
+- Pull strips that partition label back out of local issue labels so it does not become user-managed metadata.
+- Smart Commits and the Jira Development panel continue to key off the Jira issue key (`PLAT-123`), not the label.
+
+## 8. Smoke test: create and sync
 
 ```bash
 tsk new -p my-jira --title "Wire up deploy pipeline"
 tsk sync push -p my-jira
 ```
 
-Open the issue in Jira. It should exist under project `PROJ` with type `Task`. The returned `PROJ-N` key becomes the canonical ID.
+Open the issue in Jira. It should exist under Jira project `PROJ` with type `Task`. The returned `PROJ-N` key becomes the canonical ID.
 
 Pull from Jira to populate additional issues:
 
@@ -134,7 +182,7 @@ tsk sync pull -p my-jira
 tsk ls -p my-jira
 ```
 
-## 8. Full loop: start → MR → done
+## 9. Full loop: start → MR → done
 
 From the project directory:
 
@@ -157,12 +205,12 @@ tsk pr                         # view the MR URL
 tsk done                       # merge the MR and transition the Jira issue to Done
 ```
 
-`tsk done` with a Jira backend:
+`tsk done` with a Jira TasksBackend:
 
-- Merges the MR on GitLab (via `vc: my-gitlab`).
+- Merges the MR on GitLab (via the RepoProject's VCBackend).
 - Transitions the Jira issue to its **Done** status and sets resolution to `Done`. `--reason not_planned` → `Won't Do`; `--reason duplicate` → `Duplicate`.
 
-## 9. Verify the Jira ↔ GitLab link
+## 10. Verify the Jira ↔ GitLab link
 
 On the Jira issue page, open the **Development** panel (right sidebar). You should see:
 
@@ -181,12 +229,12 @@ If this panel is empty, the GitLab ↔ Jira integration app is not installed on 
 
 | Symptom | Cause / fix |
 |---|---|
-| `tsk start` says "No version control backend configured" | `vc:` missing on the Jira backend, or the referenced backend name doesn't exist. |
+| `tsk start` says "No version control backend configured" | The RepoProject's VCBackend is local or otherwise not configured for remote branch/PR work. |
 | `tsk new -p my-jira` fails with 401 | `JIRA_API_TOKEN` / `JIRA_EMAIL` wrong, or Server/DC instance needs `JIRA_AUTH_TYPE=bearer`. |
 | `tsk sync push` fails with "issue type does not exist" | `default_issue_type` doesn't match a type in the Jira project. Check **Project settings → Issue types**. |
 | MR is created but Jira shows nothing in Development panel | GitLab ↔ Jira app not installed — see step 9. The key is in the MR title regardless. |
 | `tsk done` merges MR but leaves Jira issue open | The Jira workflow has no transition named `Done` reachable from the current status. Ask the Jira admin to expose a `Done`-category transition, or transition manually. |
-| `PROJ-123` not recognized as a Jira issue key | `repo` field isn't `org/PROJECT_KEY`, or `key` override is needed — see the `key` field in the main [README](../../README.md#manual-backend-configuration). |
+| `PROJ-123` not recognized as a Jira issue key | The JiraProject field is wrong, or a RepoProject key override is needed — see the configuration docs in the main [README](../../README.md#configuration). |
 
 ## Rollout tips for teams
 

--- a/src/adapters/jira.rs
+++ b/src/adapters/jira.rs
@@ -464,9 +464,7 @@ pub fn upsert_to_jira_create(
             serde_json::Value::String(upsert.body.clone()),
         );
     }
-    if !upsert.labels.is_empty() {
-        map.insert("labels".into(), serde_json::json!(upsert.labels));
-    }
+    map.insert("labels".into(), serde_json::json!(upsert.labels));
     if let Some(milestone_id) = upsert.milestone_id {
         map.insert(
             "fixVersions".into(),
@@ -531,9 +529,11 @@ pub struct JiraProvider {
     host: String,
     /// Pre-computed `Authorization` header value (Basic or Bearer).
     auth_header: String,
-    /// Configured default issue type for creation (from `BackendConfig.default_issue_type`).
+    /// Configured default issue type for creation (from `TasksBackendSpec.default_issue_type`).
     /// When set, skips the create metadata API call to discover valid types.
     configured_issue_type: Option<String>,
+    /// Optional RepoProject label used to partition a shared Jira project.
+    repo_project_label: Option<String>,
 }
 
 impl std::fmt::Debug for JiraProvider {
@@ -546,13 +546,14 @@ impl std::fmt::Debug for JiraProvider {
 
 impl JiraProvider {
     pub fn new(host: &str, auth: JiraAuth) -> Result<Self, RiptskError> {
-        Self::with_issue_type(host, auth, None)
+        Self::with_config(host, auth, None, None)
     }
 
-    pub fn with_issue_type(
+    pub fn with_config(
         host: &str,
         auth: JiraAuth,
         configured_issue_type: Option<String>,
+        repo_project_label: Option<String>,
     ) -> Result<Self, RiptskError> {
         let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
         let auth_header = match auth {
@@ -575,7 +576,17 @@ impl JiraProvider {
             host: host.trim_end_matches('/').to_owned(),
             auth_header,
             configured_issue_type,
+            repo_project_label,
         })
+    }
+
+    fn build_list_jql(project_key: &str, repo_project_label: Option<&str>) -> String {
+        let mut jql = format!("project = {project_key}");
+        if let Some(label) = repo_project_label {
+            jql.push_str(&format!(" AND labels = \"{label}\""));
+        }
+        jql.push_str(" ORDER BY updated DESC");
+        jql
     }
 
     fn api_url(&self, path: &str) -> String {
@@ -906,7 +917,7 @@ impl JiraProvider {
 impl IssueTracker for JiraProvider {
     async fn list_issues(&self, repo: &str) -> Result<Vec<BackendIssueRecord>, RiptskError> {
         let project_key = Self::project_key(repo);
-        let jql = format!("project = {project_key} ORDER BY updated DESC");
+        let jql = Self::build_list_jql(project_key, self.repo_project_label.as_deref());
         let issues = self.search_issues(&jql).await?;
         Ok(issues
             .iter()
@@ -1418,6 +1429,22 @@ mod tests {
         assert!(json["fields"]["description"].is_null());
         assert!(json["fields"]["fixVersions"].as_array().unwrap().is_empty());
         assert!(json["fields"]["duedate"].is_null());
+    }
+
+    #[test]
+    fn list_issues_jql_without_label() {
+        assert_eq!(
+            JiraProvider::build_list_jql("PROJ", None),
+            "project = PROJ ORDER BY updated DESC"
+        );
+    }
+
+    #[test]
+    fn list_issues_jql_with_label() {
+        assert_eq!(
+            JiraProvider::build_list_jql("PROJ", Some("proj::repo-a")),
+            "project = PROJ AND labels = \"proj::repo-a\" ORDER BY updated DESC"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/src/assets/pre-commit.sh
+++ b/src/assets/pre-commit.sh
@@ -71,8 +71,8 @@ validate_config_file() {
     yq '.' "$file" >/dev/null 2>&1 || { report_fail "$file" "invalid YAML"; return; }
     # Check name uniqueness
     local dup_name
-    dup_name="$(yq -o=json '.backends // []' "$file" | jq -r '[.[].name] | group_by(.) | map(select(length > 1)) | .[0][0] // empty')"
-    [[ -z "$dup_name" ]] || report_fail "$file" "duplicate backend name \"$dup_name\""
+    dup_name="$(yq -o=json '.projects // []' "$file" | jq -r '[.[].name] | group_by(.) | map(select(length > 1)) | .[0][0] // empty')"
+    [[ -z "$dup_name" ]] || report_fail "$file" "duplicate RepoProject name \"$dup_name\""
     # Check board name uniqueness
     local dup_board
     dup_board="$(yq -o=json '.boards // []' "$file" | jq -r '[.[].name] | group_by(.) | map(select(length > 1)) | .[0][0] // empty')"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -90,10 +90,10 @@ pub struct Cli {
 
 #[derive(Debug, Clone, Args, Default)]
 pub struct ScopeArgs {
-    /// Limit to specific projects
+    /// Limit to specific RepoProjects
     #[arg(long = "project", short = 'p')]
     pub projects: Vec<String>,
-    /// Run across all registered projects
+    /// Run across all registered RepoProjects
     #[arg(long = "all-projects", short = 'a')]
     pub all_projects: bool,
 }
@@ -387,7 +387,7 @@ pub struct NewArgs {
     /// Force AI helper to fill missing fields (e.g. description) when --title is set
     #[arg(long)]
     pub ai: bool,
-    /// Target project
+    /// Target RepoProject
     #[arg(short = 'p', long)]
     pub project: Option<String>,
     /// Board to assign
@@ -714,9 +714,12 @@ pub enum TemplateSubcommand {
 
 #[derive(Debug, Clone, Args, Default)]
 pub struct RegisterArgs {
-    /// List registered backend projects
+    /// List registered RepoProjects
     #[arg(long)]
     pub list: bool,
+    /// Override the auto-derived repo-project label (used to partition a shared Jira project)
+    #[arg(long = "repo-project-label", alias = "project-label")]
+    pub repo_project_label: Option<String>,
 }
 
 #[derive(Debug, Clone, Args, Default)]
@@ -727,7 +730,7 @@ pub struct SummarizeArgs {
     /// Limit summary to a specific board
     #[arg(short = 'b', long)]
     pub board: Option<String>,
-    /// Limit summary to a specific project
+    /// Limit summary to a specific RepoProject
     #[arg(short = 'p', long)]
     pub project: Option<String>,
 }

--- a/src/commands/branch.rs
+++ b/src/commands/branch.rs
@@ -3,12 +3,10 @@ use crate::adapters::prompts::{DialoguerPrompts, PromptBackend};
 use crate::cli::BranchArgs;
 use crate::config::{Config, load_config};
 use crate::error::RiptskError;
-use crate::models::{Backend, BackendConfig};
+use crate::models::{BackendKind, RepoProject};
 use crate::paths::AppPaths;
 use crate::services::auto_commit::maybe_auto_commit;
-use crate::services::backend_mapping::{
-    build_version_control, resolve_git_auth, resolve_vc_for_backend,
-};
+use crate::services::backend_mapping::{build_version_control, resolve_git_auth};
 use crate::services::issue_service::generate_branch_slug;
 use crate::services::{id_resolution, project_detection};
 use crate::storage::{frontmatter, issue_store};
@@ -47,43 +45,34 @@ pub(crate) async fn create_branch_for_issue(
     let path = issue_store::find_issue(paths, id)?;
     let mut issue = crate::commands::issues::load_issue_or_conflict_error(path.as_std_path(), id)?;
 
-    let backend = config
-        .backends
+    let repo_project = config
+        .projects
         .iter()
-        .find(|b| b.name == issue.frontmatter.project)
+        .find(|rp| rp.name == issue.frontmatter.project)
         .ok_or_else(|| RiptskError::Unregistered(issue.frontmatter.project.clone()))?;
-    if backend.backend == Backend::Local {
+    if repo_project.vc_backend.kind == BackendKind::Local {
         return Err(RiptskError::Config(
             "cannot create remote branch for local-only project".into(),
         ));
     }
 
-    let issue_number = backend_issue_number(backend, &issue)?;
+    let issue_number = backend_issue_number(repo_project, &issue)?;
 
     let slug = generate_branch_slug(issue_number, &issue.frontmatter.title);
 
     let repo = current_repo()?;
 
     // For Jira backends, resolve the VC backend for branch/PR operations
-    let (vc_provider, vc_backend, vc_issue_id) = if backend.backend == Backend::Jira {
-        let (provider, vc_backend) =
-            resolve_vc_for_backend(backend, &config)?.ok_or_else(|| {
-                RiptskError::Config(format!(
-                    "No version control backend configured for project '{}'. \
-                     Add 'vc: <github-or-gitlab-backend>' to the backend config.",
-                    backend.name
-                ))
-            })?;
-        // Don't link to a GitHub/GitLab issue — the issue lives in Jira
-        (provider, vc_backend.clone(), None)
+    let vc_provider = build_version_control(&repo_project.vc_backend, &repo_project.name)?;
+    let vc_issue_id = if repo_project.tasks_backend.kind == BackendKind::Jira {
+        None
     } else {
-        let provider = build_version_control(backend)?;
-        (provider, backend.clone(), Some(issue_number))
+        Some(issue_number)
     };
 
-    let auth = resolve_git_auth(&vc_backend);
+    let auth = resolve_git_auth(&repo_project.vc_backend, &repo_project.name);
     let git = CliGit::with_auth(auth);
-    let repo_name = vc_backend.repo.as_deref().unwrap_or_default();
+    let repo_name = repo_project.vc_backend.repo.as_deref().unwrap_or_default();
     let base = crate::ui::spin_on_async("Fetching default branch", async {
         vc_provider.default_branch(repo_name).await
     })
@@ -103,7 +92,7 @@ pub(crate) async fn create_branch_for_issue(
         }
         Err(e) => return Err(e),
     }
-    tracing::info!(branch = %slug, backend = %vc_backend.name, "ensured remote branch exists");
+    tracing::info!(branch = %slug, backend = %repo_project.name, "ensured remote branch exists");
 
     if !git.branch_exists(repo.as_path(), &slug)? {
         crate::ui::spin_on("Checking out branch", || {
@@ -160,12 +149,12 @@ async fn delete_branch(paths: &AppPaths, args: BranchArgs) -> Result<(), RiptskE
         Err(RiptskError::NotFound(_)) => None,
         Err(e) => return Err(e),
     };
-    let (vc_backend, default_branch) =
+    let (repo_project, default_branch) =
         resolve_backend_and_default(&config, &cwd, issue_path.as_ref()).await?;
-    let auth = resolve_git_auth(&vc_backend);
+    let auth = resolve_git_auth(&repo_project.vc_backend, &repo_project.name);
     let git = CliGit::with_auth(auth);
-    let provider = build_version_control(&vc_backend)?;
-    let repo_name = vc_backend.repo.as_deref().unwrap_or_default();
+    let provider = build_version_control(&repo_project.vc_backend, &repo_project.name)?;
+    let repo_name = repo_project.vc_backend.repo.as_deref().unwrap_or_default();
 
     let fetch_spinner = crate::ui::spinner("Fetching remote branches".to_owned());
     let fetch_result = git.fetch(repo.as_path());
@@ -215,7 +204,7 @@ async fn delete_branch(paths: &AppPaths, args: BranchArgs) -> Result<(), RiptskE
         }
         Err(e) => return Err(e),
     }
-    tracing::info!(branch = %target_branch, backend = %vc_backend.name, "remote branch deletion finished");
+    tracing::info!(branch = %target_branch, backend = %repo_project.name, "remote branch deletion finished");
 
     if deleting_current && let Err(e) = git.checkout(repo.as_path(), &default_branch) {
         return Err(RiptskError::General(format!(
@@ -275,63 +264,51 @@ async fn resolve_backend_and_default(
     config: &Config,
     cwd: &camino::Utf8Path,
     issue_path: Option<&camino::Utf8PathBuf>,
-) -> Result<(BackendConfig, String), RiptskError> {
-    let backend = if let Some(path) = issue_path {
+) -> Result<(RepoProject, String), RiptskError> {
+    let repo_project = if let Some(path) = issue_path {
         let id = path.file_stem().unwrap_or_default().to_string();
         let issue = crate::commands::issues::load_issue_or_conflict_error(path.as_std_path(), &id)?;
         config
-            .backends
+            .projects
             .iter()
-            .find(|b| b.name == issue.frontmatter.project)
+            .find(|rp| rp.name == issue.frontmatter.project)
             .ok_or_else(|| RiptskError::Unregistered(issue.frontmatter.project.clone()))?
             .clone()
     } else {
-        project_detection::detect_from_cwd(cwd, config)?.ok_or_else(|| {
-            RiptskError::Config("cannot determine project for branch deletion".into())
-        })?
-    };
-
-    // For Jira backends, resolve the VC backend
-    let vc_backend = if backend.backend == Backend::Jira {
-        resolve_vc_for_backend(&backend, config)?
-            .map(|(_, vc_b)| vc_b.clone())
+        project_detection::detect_from_cwd(cwd, config)?
+            .cloned()
             .ok_or_else(|| {
-                RiptskError::Config(format!(
-                    "No version control backend for project '{}'. Add 'vc' to the backend config.",
-                    backend.name
-                ))
+                RiptskError::Config("cannot determine project for branch deletion".into())
             })?
-    } else {
-        backend
     };
 
-    let provider = build_version_control(&vc_backend)?;
-    let repo_name = vc_backend.repo.as_deref().unwrap_or_default();
+    let provider = build_version_control(&repo_project.vc_backend, &repo_project.name)?;
+    let repo_name = repo_project.vc_backend.repo.as_deref().unwrap_or_default();
     let default = provider.default_branch(repo_name).await?;
-    Ok((vc_backend, default))
+    Ok((repo_project, default))
 }
 
 pub(crate) fn backend_issue_number(
-    backend: &BackendConfig,
+    repo_project: &RepoProject,
     issue: &crate::domain::issue::IssueDocument,
 ) -> Result<u64, RiptskError> {
-    match backend.backend {
-        Backend::Github => issue
+    match repo_project.tasks_backend.kind {
+        BackendKind::Github => issue
             .frontmatter
             .github
             .as_ref()
             .and_then(|meta| meta.issue_id),
-        Backend::Gitlab => issue
+        BackendKind::Gitlab => issue
             .frontmatter
             .gitlab
             .as_ref()
             .and_then(|meta| meta.issue_id),
-        Backend::Jira => issue
+        BackendKind::Jira => issue
             .frontmatter
             .jira
             .as_ref()
             .and_then(|meta| meta.issue_id),
-        Backend::Local => None,
+        BackendKind::Local => None,
     }
     .ok_or_else(|| {
         RiptskError::Config(format!(

--- a/src/commands/clone_cmd.rs
+++ b/src/commands/clone_cmd.rs
@@ -4,12 +4,10 @@ use crate::commands::branch::{backend_issue_number, cwd_utf8};
 use crate::config::load_config;
 use crate::domain::work_clone::WorkCloneMarker;
 use crate::error::RiptskError;
-use crate::models::Backend;
+use crate::models::BackendKind;
 use crate::paths::AppPaths;
 use crate::services::auto_commit::maybe_auto_commit;
-use crate::services::backend_mapping::{
-    build_version_control, resolve_git_auth, resolve_vc_for_backend,
-};
+use crate::services::backend_mapping::{build_version_control, resolve_git_auth};
 use crate::services::id_resolution;
 use crate::services::issue_service::generate_branch_slug;
 use crate::storage::{frontmatter, issue_store, work_clone};
@@ -26,38 +24,30 @@ pub async fn run(paths: &AppPaths, args: CloneArgs) -> Result<(), RiptskError> {
 
     let path = issue_store::find_issue(paths, &id)?;
     let mut issue = crate::commands::issues::load_issue_or_conflict_error(path.as_std_path(), &id)?;
-    let backend = config
-        .backends
+    let repo_project = config
+        .projects
         .iter()
-        .find(|b| b.name == issue.frontmatter.project)
+        .find(|rp| rp.name == issue.frontmatter.project)
         .ok_or_else(|| RiptskError::Unregistered(issue.frontmatter.project.clone()))?;
-    if backend.backend == Backend::Local {
+    if repo_project.vc_backend.kind == BackendKind::Local {
         return Err(RiptskError::Config(
             "cannot create remote branch for local-only project".into(),
         ));
     }
 
-    let issue_number = backend_issue_number(backend, &issue)?;
+    let issue_number = backend_issue_number(repo_project, &issue)?;
     let slug = generate_branch_slug(issue_number, &issue.frontmatter.title);
 
-    let (vc_provider, vc_backend, vc_issue_id) = if backend.backend == Backend::Jira {
-        let (provider, vc_backend) =
-            resolve_vc_for_backend(backend, &config)?.ok_or_else(|| {
-                RiptskError::Config(format!(
-                    "No version control backend configured for project '{}'. \
-                     Add 'vc: <github-or-gitlab-backend>' to the backend config.",
-                    backend.name
-                ))
-            })?;
-        (provider, vc_backend.clone(), None)
+    let vc_provider = build_version_control(&repo_project.vc_backend, &repo_project.name)?;
+    let vc_issue_id = if repo_project.tasks_backend.kind == BackendKind::Jira {
+        None
     } else {
-        let provider = build_version_control(backend)?;
-        (provider, backend.clone(), Some(issue_number))
+        Some(issue_number)
     };
 
-    let auth = resolve_git_auth(&vc_backend);
+    let auth = resolve_git_auth(&repo_project.vc_backend, &repo_project.name);
     let git = CliGit::with_auth(auth);
-    let repo_name = vc_backend.repo.as_deref().unwrap_or_default();
+    let repo_name = repo_project.vc_backend.repo.as_deref().unwrap_or_default();
     let base = crate::ui::spin_on_async("Fetching default branch", async {
         vc_provider.default_branch(repo_name).await
     })
@@ -77,7 +67,7 @@ pub async fn run(paths: &AppPaths, args: CloneArgs) -> Result<(), RiptskError> {
         }
         Err(error) => return Err(error),
     }
-    tracing::info!(branch = %slug, backend = %vc_backend.name, "ensured remote branch exists for clone");
+    tracing::info!(branch = %slug, backend = %repo_project.name, "ensured remote branch exists for clone");
 
     issue.frontmatter.id_slug = Some(slug.clone());
     issue.frontmatter.branch = Some(slug.clone());

--- a/src/commands/done.rs
+++ b/src/commands/done.rs
@@ -7,11 +7,11 @@ use crate::commands::{pr, sync_cmd};
 use crate::config::load_config;
 use crate::domain::issue::{IssueDocument, IssueState};
 use crate::error::RiptskError;
-use crate::models::Backend;
+use crate::models::BackendKind;
 use crate::paths::AppPaths;
 use crate::services::auto_commit::maybe_auto_commit;
 use crate::services::backend_mapping::{
-    build_provider_for_backend, resolve_git_auth, update_issue_from_backend,
+    build_hosted_provider, resolve_git_auth, update_issue_from_backend,
 };
 use crate::services::id_resolution;
 use crate::services::issue_service::now_utc;
@@ -94,17 +94,13 @@ pub async fn run(paths: &AppPaths, args: DoneArgs) -> Result<(), RiptskError> {
         crate::commands::issues::load_issue_or_conflict_error(issue_path.as_std_path(), &id)?;
 
     // Check if this is a Jira-only (no VC) project
-    let issue_backend = config
-        .backends
+    let repo_project = config
+        .projects
         .iter()
-        .find(|b| b.name == issue.frontmatter.project)
+        .find(|rp| rp.name == issue.frontmatter.project)
         .ok_or_else(|| RiptskError::Unregistered(issue.frontmatter.project.clone()))?;
 
-    let has_vc = match issue_backend.backend {
-        Backend::Github | Backend::Gitlab => true,
-        Backend::Jira => issue_backend.vc.is_some(),
-        Backend::Local => false,
-    };
+    let has_vc = repo_project.vc_backend.kind != BackendKind::Local;
 
     if !has_vc || issue.frontmatter.branch.is_none() {
         // Issue-only workflow: just mark done locally and sync
@@ -144,10 +140,13 @@ pub async fn run(paths: &AppPaths, args: DoneArgs) -> Result<(), RiptskError> {
 
     // Full VC workflow: merge PR, delete branch, close issue
     let branch_name = issue.frontmatter.branch.clone().unwrap();
-    let backend = pr::resolve_hosted_backend(&config, &issue)?;
-    let provider = build_provider_for_backend(backend)?;
-    let repo_name = backend.repo.as_deref().unwrap_or_default();
-    let git = CliGit::with_auth(resolve_git_auth(backend));
+    let repo_project = pr::resolve_hosted_repo_project(&config, &issue)?;
+    let provider = build_hosted_provider(&repo_project.vc_backend, &repo_project.name)?;
+    let repo_name = repo_project.vc_backend.repo.as_deref().unwrap_or_default();
+    let git = CliGit::with_auth(resolve_git_auth(
+        &repo_project.vc_backend,
+        &repo_project.name,
+    ));
     let repo_dir = current_repo()?;
     let original_branch = git.current_branch(repo_dir.as_path()).ok();
 
@@ -201,7 +200,7 @@ pub async fn run(paths: &AppPaths, args: DoneArgs) -> Result<(), RiptskError> {
             provider.as_ref(),
             &DialoguerPrompts,
             &git,
-            backend.backend.clone(),
+            repo_project.vc_backend.kind.clone(),
             repo_dir.as_path(),
             repo_name,
             pr_number,
@@ -215,7 +214,7 @@ pub async fn run(paths: &AppPaths, args: DoneArgs) -> Result<(), RiptskError> {
             return Ok(());
         }
 
-        let closed_record = match backend_issue_number(backend, &issue)
+        let closed_record = match backend_issue_number(repo_project, &issue)
             .ok()
             .zip(Some(repo_name))
         {
@@ -275,13 +274,18 @@ pub async fn run(paths: &AppPaths, args: DoneArgs) -> Result<(), RiptskError> {
                 issue_path.as_std_path(),
                 &id,
             )?;
-            update_issue_from_backend(&mut issue, record, backend);
+            update_issue_from_backend(&mut issue, record, repo_project);
             issue.frontmatter.branch = None;
             issue.frontmatter.id_slug = None;
             frontmatter::save_issue(issue_path.as_std_path(), &issue)
                 .map_err(RiptskError::Other)?;
-            cache::seed_backend_state_entry(paths, backend.backend.as_str(), repo_name, record)
-                .map_err(RiptskError::Other)?;
+            cache::seed_backend_state_entry(
+                paths,
+                repo_project.tasks_backend.kind.as_str(),
+                repo_name,
+                record,
+            )
+            .map_err(RiptskError::Other)?;
         } else {
             let mut issue =
                 frontmatter::load_issue(issue_path.as_std_path()).map_err(RiptskError::Other)?;

--- a/src/commands/issues.rs
+++ b/src/commands/issues.rs
@@ -11,10 +11,10 @@ use crate::domain::issue::{
     Priority,
 };
 use crate::error::RiptskError;
-use crate::models::{Backend, BackendConfig};
+use crate::models::{BackendKind, RepoProject};
 use crate::paths::AppPaths;
 use crate::services::auto_commit::maybe_auto_commit;
-use crate::services::backend_mapping::build_state_labels;
+use crate::services::backend_mapping::{build_state_labels, effective_repo_project_label};
 use crate::services::id_resolution;
 use crate::services::issue_ids;
 use crate::services::issue_service::{IssueDraft, IssueService, generate_slug};
@@ -267,9 +267,10 @@ pub(crate) async fn create_issue_from_args(
             .to_string(),
     );
     if args.project.is_none()
-        && let Some(backend) = crate::services::project_detection::detect_from_cwd(&cwd, &config)?
+        && let Some(repo_project) =
+            crate::services::project_detection::detect_from_cwd(&cwd, &config)?
     {
-        args.project = Some(backend.name);
+        args.project = Some(repo_project.name.clone());
     }
     let edit = args.edit;
     let prompts = DialoguerPrompts;
@@ -337,17 +338,18 @@ pub(crate) async fn create_issue_from_args(
     {
         draft.body = body;
     }
-    let issue = if draft
-        .backend
-        .as_ref()
-        .is_some_and(|backend| matches!(backend, Backend::Github | Backend::Gitlab))
-    {
-        let backend = config
-            .backends
+    let issue = if draft.tasks_backend_kind.as_ref().is_some_and(|kind| {
+        matches!(
+            kind,
+            BackendKind::Github | BackendKind::Gitlab | BackendKind::Jira
+        )
+    }) {
+        let repo_project = config
+            .projects
             .iter()
-            .find(|backend| backend.name == draft.project)
+            .find(|repo_project| repo_project.name == draft.project)
             .ok_or_else(|| RiptskError::Unregistered(draft.project.clone()))?;
-        create_backend_issue(paths, &service, &draft, backend).await?
+        create_backend_issue(paths, &service, &draft, repo_project).await?
     } else {
         create_local_issue(&service, &draft)?
     };
@@ -414,10 +416,16 @@ fn resolve_project_repo_path(
 ) -> camino::Utf8PathBuf {
     if let Some(project) = project
         && let Some(path) = config
-            .backends
+            .projects
             .iter()
-            .find(|backend| backend.name == project)
-            .and_then(|backend| backend.path.as_ref())
+            .find(|repo_project| repo_project.name == project)
+            .and_then(|repo_project| {
+                repo_project
+                    .vc_backend
+                    .path
+                    .as_ref()
+                    .or(repo_project.tasks_backend.path.as_ref())
+            })
     {
         return camino::Utf8PathBuf::from(path);
     }
@@ -657,19 +665,47 @@ async fn create_backend_issue(
     paths: &AppPaths,
     service: &IssueService<'_>,
     draft: &IssueDraft,
-    backend: &BackendConfig,
+    repo_project: &RepoProject,
 ) -> Result<IssueDocument, RiptskError> {
-    let provider = crate::services::backend_mapping::build_issue_tracker(backend)?;
-    let repo = backend
-        .repo
-        .as_deref()
-        .ok_or_else(|| RiptskError::Config(format!("backend {} is missing repo", backend.name)))?;
+    let provider = crate::services::backend_mapping::build_issue_tracker(repo_project)?;
+    let repo = match repo_project.tasks_backend.kind {
+        BackendKind::Github | BackendKind::Gitlab => {
+            repo_project.tasks_backend.repo.as_deref().ok_or_else(|| {
+                RiptskError::Config(format!(
+                    "RepoProject {} is missing TasksBackend repo",
+                    repo_project.name
+                ))
+            })?
+        }
+        BackendKind::Jira => repo_project
+            .tasks_backend
+            .jira_project
+            .as_deref()
+            .ok_or_else(|| {
+                RiptskError::Config(format!(
+                    "RepoProject {} is missing JiraProject",
+                    repo_project.name
+                ))
+            })?,
+        BackendKind::Local => {
+            return Err(RiptskError::Config(format!(
+                "RepoProject {} does not have a hosted TasksBackend",
+                repo_project.name
+            )));
+        }
+    };
+    let mut upsert_labels = build_state_labels(&draft.status, &draft.labels);
+    if let Some(label) = effective_repo_project_label(repo_project)
+        && !upsert_labels.iter().any(|candidate| candidate == label)
+    {
+        upsert_labels.push(label.to_owned());
+    }
     let upsert = BackendIssueUpsert {
         title: draft.title.clone(),
         body: draft.body.clone(),
         state: None,
         state_reason: None,
-        labels: build_state_labels(&draft.status, &draft.labels),
+        labels: upsert_labels,
         assignees: draft.assignee.clone().into_iter().collect(),
         milestone_id: None,
         due_date: None,
@@ -683,7 +719,7 @@ async fn create_backend_issue(
         provider.create_issue(repo, &upsert).await
     })
     .await?;
-    let scope = issue_ids::effective_key(backend);
+    let scope = issue_ids::effective_key(repo_project);
     let id = issue_ids::format_id(&scope, record.issue_id);
     let document = IssueDocument {
         frontmatter: IssueFrontmatter {
@@ -700,7 +736,7 @@ async fn create_backend_issue(
             state_reason: record.state_reason.clone(),
             cycle: None,
             order: Some(draft.order),
-            gitlab: if backend.backend == Backend::Gitlab {
+            gitlab: if repo_project.tasks_backend.kind == BackendKind::Gitlab {
                 Some(GitlabIssueMeta {
                     repo: repo.to_owned(),
                     issue_id: Some(record.issue_id),
@@ -712,7 +748,7 @@ async fn create_backend_issue(
             } else {
                 None
             },
-            github: if backend.backend == Backend::Github {
+            github: if repo_project.tasks_backend.kind == BackendKind::Github {
                 Some(GithubIssueMeta {
                     repo: repo.to_owned(),
                     issue_id: Some(record.issue_id),
@@ -725,7 +761,7 @@ async fn create_backend_issue(
             } else {
                 None
             },
-            jira: if backend.backend == Backend::Jira {
+            jira: if repo_project.tasks_backend.kind == BackendKind::Jira {
                 let issue_key = record.url.rsplit('/').next().map(|s| s.to_owned());
                 Some(JiraIssueMeta {
                     project_key: crate::adapters::jira::JiraProvider::project_key(repo).to_owned(),
@@ -760,12 +796,12 @@ async fn create_backend_issue(
         remote_section: None,
     };
     service.persist_issue(&document)?;
-    cache::seed_backend_state_entry(paths, provider_name(backend), repo, &record)
+    cache::seed_backend_state_entry(paths, provider_name(repo_project), repo, &record)
         .map_err(RiptskError::Other)?;
     tracing::info!(
         issue_id = %document.frontmatter.id,
         project = %document.frontmatter.project,
-        backend = %backend.name,
+        repo_project = %repo_project.name,
         "created issue"
     );
     Ok(document)
@@ -780,12 +816,12 @@ fn create_local_issue(
     Ok(document)
 }
 
-fn provider_name(backend: &BackendConfig) -> &'static str {
-    match backend.backend {
-        Backend::Github => "github",
-        Backend::Gitlab => "gitlab",
-        Backend::Jira => "jira",
-        Backend::Local => "local",
+fn provider_name(repo_project: &RepoProject) -> &'static str {
+    match repo_project.tasks_backend.kind {
+        BackendKind::Github => "github",
+        BackendKind::Gitlab => "gitlab",
+        BackendKind::Jira => "jira",
+        BackendKind::Local => "local",
     }
 }
 

--- a/src/commands/pr.rs
+++ b/src/commands/pr.rs
@@ -10,10 +10,10 @@ use crate::commands::branch::{backend_issue_number, current_repo, cwd_utf8};
 use crate::config::{Config, load_config};
 use crate::domain::issue::{IssueDocument, IssueState};
 use crate::error::RiptskError;
-use crate::models::{Backend, BackendConfig};
+use crate::models::{BackendKind, RepoProject};
 use crate::paths::AppPaths;
 use crate::services::auto_commit::maybe_auto_commit;
-use crate::services::backend_mapping::{build_provider_for_backend, resolve_git_auth};
+use crate::services::backend_mapping::{build_hosted_provider, resolve_git_auth};
 use crate::services::id_resolution;
 use crate::services::issue_service::now_utc;
 use crate::storage::{frontmatter, issue_store};
@@ -64,10 +64,13 @@ pub(crate) async fn create(paths: &AppPaths, args: PrCreateArgs) -> Result<(), R
         ));
     }
 
-    let backend = resolve_hosted_backend(&config, &issue)?;
-    let git = CliGit::with_auth(resolve_git_auth(backend));
-    let provider = build_provider_for_backend(backend)?;
-    let repo_name = backend.repo.as_deref().unwrap_or_default();
+    let repo_project = resolve_hosted_repo_project(&config, &issue)?;
+    let git = CliGit::with_auth(resolve_git_auth(
+        &repo_project.vc_backend,
+        &repo_project.name,
+    ));
+    let provider = build_hosted_provider(&repo_project.vc_backend, &repo_project.name)?;
+    let repo_name = repo_project.vc_backend.repo.as_deref().unwrap_or_default();
     let default_branch = ui::spin_on_async("Fetching default branch", async {
         provider.default_branch(repo_name).await
     })
@@ -109,7 +112,7 @@ pub(crate) async fn create(paths: &AppPaths, args: PrCreateArgs) -> Result<(), R
     })?;
 
     let mut skip_ai = false;
-    if backend.backend == Backend::Github
+    if repo_project.vc_backend.kind == BackendKind::Github
         && git.commits_ahead_of_base(repo.as_path(), &branch, &default_branch)? == 0
     {
         if git.has_staged_changes(repo.as_path())? {
@@ -136,7 +139,7 @@ pub(crate) async fn create(paths: &AppPaths, args: PrCreateArgs) -> Result<(), R
             format!("Jira: {key}"),
         )
     } else {
-        let issue_number = backend_issue_number(backend, &issue)?;
+        let issue_number = backend_issue_number(repo_project, &issue)?;
         (
             default_title(issue_number, &issue.frontmatter.title),
             default_body(issue_number),
@@ -188,9 +191,9 @@ async fn show(paths: &AppPaths, args: PrShowArgs) -> Result<(), RiptskError> {
     paths.require_initialized()?;
     let config = load_config(paths.config_path().as_std_path())?;
     let (_path, issue) = resolve_issue(paths, &config, &args.scope, args.id.as_deref())?;
-    let backend = resolve_hosted_backend(&config, &issue)?;
-    let provider = build_provider_for_backend(backend)?;
-    let repo_name = backend.repo.as_deref().unwrap_or_default();
+    let repo_project = resolve_hosted_repo_project(&config, &issue)?;
+    let provider = build_hosted_provider(&repo_project.vc_backend, &repo_project.name)?;
+    let repo_name = repo_project.vc_backend.repo.as_deref().unwrap_or_default();
     let pr_number = resolve_pr_number(provider.as_ref(), repo_name, &issue).await?;
     let record = ui::spin_on_async("Fetching PR details", async {
         provider.get_pr(repo_name, pr_number).await
@@ -218,8 +221,11 @@ async fn merge(paths: &AppPaths, args: PrMergeArgs) -> Result<(), RiptskError> {
     paths.require_initialized()?;
     let config = load_config(paths.config_path().as_std_path())?;
     let (_path, issue) = resolve_issue(paths, &config, &args.scope, args.id.as_deref())?;
-    let backend = resolve_hosted_backend(&config, &issue)?;
-    let git = CliGit::with_auth(resolve_git_auth(backend));
+    let repo_project = resolve_hosted_repo_project(&config, &issue)?;
+    let git = CliGit::with_auth(resolve_git_auth(
+        &repo_project.vc_backend,
+        &repo_project.name,
+    ));
     let repo_path = current_repo()?;
     let stashed = if git.has_working_tree_changes(repo_path.as_path())? {
         let current_branch = git.current_branch(repo_path.as_path()).unwrap_or_default();
@@ -234,8 +240,8 @@ async fn merge(paths: &AppPaths, args: PrMergeArgs) -> Result<(), RiptskError> {
     } else {
         false
     };
-    let provider = build_provider_for_backend(backend)?;
-    let repo_name = backend.repo.as_deref().unwrap_or_default();
+    let provider = build_hosted_provider(&repo_project.vc_backend, &repo_project.name)?;
+    let repo_name = repo_project.vc_backend.repo.as_deref().unwrap_or_default();
     let pr_number = resolve_pr_number(provider.as_ref(), repo_name, &issue).await?;
     let opts = MergeOptions {
         merge_method: args.merge_method.unwrap_or_default(),
@@ -249,7 +255,7 @@ async fn merge(paths: &AppPaths, args: PrMergeArgs) -> Result<(), RiptskError> {
         provider.as_ref(),
         &DialoguerPrompts,
         &git,
-        backend.backend.clone(),
+        repo_project.vc_backend.kind.clone(),
         repo_path.as_path(),
         repo_name,
         pr_number,
@@ -267,9 +273,9 @@ async fn edit(paths: &AppPaths, args: PrEditArgs) -> Result<(), RiptskError> {
     paths.require_initialized()?;
     let config = load_config(paths.config_path().as_std_path())?;
     let (path, mut issue) = resolve_issue(paths, &config, &args.scope, args.id.as_deref())?;
-    let backend = resolve_hosted_backend(&config, &issue)?;
-    let provider = build_provider_for_backend(backend)?;
-    let repo_name = backend.repo.as_deref().unwrap_or_default();
+    let repo_project = resolve_hosted_repo_project(&config, &issue)?;
+    let provider = build_hosted_provider(&repo_project.vc_backend, &repo_project.name)?;
+    let repo_name = repo_project.vc_backend.repo.as_deref().unwrap_or_default();
     let pr_number = resolve_pr_number(provider.as_ref(), repo_name, &issue).await?;
     let current = ui::spin_on_async("Fetching PR details", async {
         provider.get_pr(repo_name, pr_number).await
@@ -376,7 +382,7 @@ pub(crate) async fn merge_pr_workflow(
     provider: &dyn VersionControl,
     prompts: &dyn PromptBackend,
     git: &dyn GitBackend,
-    backend_kind: Backend,
+    backend_kind: BackendKind,
     repo_path: &Path,
     repo_name: &str,
     pr_number: u64,
@@ -400,7 +406,7 @@ pub(crate) async fn merge_pr_workflow(
     }
 
     // Cleanup empty bootstrap commit for GitHub before merge
-    if backend_kind == Backend::Github
+    if backend_kind == BackendKind::Github
         && let Some(branch) = issue.frontmatter.branch.as_deref()
     {
         let default_branch = ui::spin_on_async("Fetching default branch", async {
@@ -499,41 +505,22 @@ fn resolve_issue(
     Ok((path, issue))
 }
 
-pub(crate) fn resolve_hosted_backend<'a>(
+pub(crate) fn resolve_hosted_repo_project<'a>(
     config: &'a Config,
     issue: &IssueDocument,
-) -> Result<&'a BackendConfig, RiptskError> {
-    let backend = config
-        .backends
+) -> Result<&'a RepoProject, RiptskError> {
+    let repo_project = config
+        .projects
         .iter()
-        .find(|backend| backend.name == issue.frontmatter.project)
+        .find(|repo_project| repo_project.name == issue.frontmatter.project)
         .ok_or_else(|| RiptskError::Unregistered(issue.frontmatter.project.clone()))?;
-    match backend.backend {
-        Backend::Github | Backend::Gitlab => Ok(backend),
-        Backend::Jira => {
-            // For Jira, resolve through the vc field
-            let vc_name = backend.vc.as_deref().ok_or_else(|| {
-                RiptskError::Config(format!(
-                    "No version control backend configured for project '{}'. \
-                     Add 'vc: <github-or-gitlab-backend>' to the backend config.",
-                    backend.name
-                ))
-            })?;
-            config
-                .backends
-                .iter()
-                .find(|b| b.name == vc_name)
-                .ok_or_else(|| {
-                    RiptskError::Config(format!(
-                        "vc backend '{}' referenced by '{}' not found",
-                        vc_name, backend.name
-                    ))
-                })
-        }
-        Backend::Local => Err(RiptskError::Config(format!(
+    if repo_project.vc_backend.kind == BackendKind::Local {
+        Err(RiptskError::Config(format!(
             "project {} does not have a hosted backend",
-            backend.name
-        ))),
+            repo_project.name
+        )))
+    } else {
+        Ok(repo_project)
     }
 }
 
@@ -617,12 +604,12 @@ fn confirm_merge(
     prompts.confirm(&prompt, false)
 }
 
-fn has_local_ci(repo_path: &Path, backend_kind: &Backend) -> bool {
+fn has_local_ci(repo_path: &Path, backend_kind: &BackendKind) -> bool {
     match backend_kind {
-        Backend::Github => has_local_github_ci(repo_path),
-        Backend::Gitlab => has_local_gitlab_ci(repo_path),
-        Backend::Jira => false,
-        Backend::Local => false,
+        BackendKind::Github => has_local_github_ci(repo_path),
+        BackendKind::Gitlab => has_local_gitlab_ci(repo_path),
+        BackendKind::Jira => false,
+        BackendKind::Local => false,
     }
 }
 
@@ -664,7 +651,7 @@ async fn handle_ci_checks(
     repo_path: &Path,
     repo_name: &str,
     pr_number: u64,
-    backend_kind: &Backend,
+    backend_kind: &BackendKind,
     opts: &MergeOptions,
 ) -> Result<PrChecksStatus, RiptskError> {
     let has_local = has_local_ci(repo_path, backend_kind);
@@ -939,7 +926,7 @@ mod tests {
     };
     use crate::adapters::prompts::PromptBackend;
     use crate::error::RiptskError;
-    use crate::models::Backend;
+    use crate::models::BackendKind;
     use async_trait::async_trait;
     use std::collections::VecDeque;
     use std::fs;
@@ -1376,7 +1363,7 @@ mod tests {
             repo.path(),
             "owner/repo",
             42,
-            &Backend::Github,
+            &BackendKind::Github,
             &merge_options(false, 1),
         )
         .await;
@@ -1406,7 +1393,7 @@ mod tests {
             repo.path(),
             "owner/repo",
             42,
-            &Backend::Github,
+            &BackendKind::Github,
             &merge_options(false, 1),
         )
         .await;
@@ -1433,7 +1420,7 @@ mod tests {
             repo.path(),
             "owner/repo",
             42,
-            &Backend::Github,
+            &BackendKind::Github,
             &merge_options(false, 1),
         )
         .await;
@@ -1459,7 +1446,7 @@ mod tests {
             repo.path(),
             "owner/repo",
             42,
-            &Backend::Github,
+            &BackendKind::Github,
             &merge_options(false, 1),
         )
         .await;
@@ -1489,7 +1476,7 @@ mod tests {
             repo.path(),
             "owner/repo",
             42,
-            &Backend::Github,
+            &BackendKind::Github,
             &merge_options(false, 1),
         )
         .await;
@@ -1516,7 +1503,7 @@ mod tests {
             repo.path(),
             "owner/repo",
             42,
-            &Backend::Github,
+            &BackendKind::Github,
             &merge_options(true, 1),
         )
         .await;

--- a/src/commands/register.rs
+++ b/src/commands/register.rs
@@ -19,28 +19,70 @@ pub fn run(paths: &AppPaths, args: RegisterArgs) -> Result<(), RiptskError> {
                 Cell::new("Name")
                     .add_attribute(Attribute::Bold)
                     .add_attribute(Attribute::Dim),
-                Cell::new("Type")
+                Cell::new("VC")
                     .add_attribute(Attribute::Bold)
                     .add_attribute(Attribute::Dim),
-                Cell::new("Repo")
+                Cell::new("Tasks")
+                    .add_attribute(Attribute::Bold)
+                    .add_attribute(Attribute::Dim),
+                Cell::new("JiraProject")
+                    .add_attribute(Attribute::Bold)
+                    .add_attribute(Attribute::Dim),
+                Cell::new("Label")
                     .add_attribute(Attribute::Bold)
                     .add_attribute(Attribute::Dim),
             ]);
-            for backend in &config.backends {
+            for repo_project in &config.projects {
                 table.add_row(vec![
-                    Cell::new(&backend.name).fg(Color::Cyan),
-                    Cell::new(backend.backend.as_str()),
-                    Cell::new(backend.repo.as_deref().unwrap_or("-")).fg(Color::Grey),
+                    Cell::new(&repo_project.name).fg(Color::Cyan),
+                    Cell::new(format_backend_cell(
+                        repo_project.vc_backend.kind.as_str(),
+                        repo_project.vc_backend.host.as_deref(),
+                        repo_project.vc_backend.repo.as_deref(),
+                        repo_project.vc_backend.path.as_deref(),
+                    )),
+                    Cell::new(format_backend_cell(
+                        repo_project.tasks_backend.kind.as_str(),
+                        repo_project.tasks_backend.host.as_deref(),
+                        repo_project.tasks_backend.repo.as_deref(),
+                        repo_project.tasks_backend.path.as_deref(),
+                    )),
+                    Cell::new(
+                        repo_project
+                            .tasks_backend
+                            .jira_project
+                            .as_deref()
+                            .unwrap_or("-"),
+                    )
+                    .fg(Color::Grey),
+                    Cell::new(repo_project.repo_project_label.as_deref().unwrap_or(""))
+                        .fg(Color::Grey),
                 ]);
             }
             println!("{table}");
         } else {
-            for backend in &config.backends {
+            for repo_project in &config.projects {
                 println!(
-                    "{}\t{}\t{}",
-                    backend.name,
-                    backend.backend.as_str(),
-                    backend.repo.as_deref().unwrap_or("")
+                    "{}\t{}\t{}\t{}\t{}",
+                    repo_project.name,
+                    format_backend_cell(
+                        repo_project.vc_backend.kind.as_str(),
+                        repo_project.vc_backend.host.as_deref(),
+                        repo_project.vc_backend.repo.as_deref(),
+                        repo_project.vc_backend.path.as_deref(),
+                    ),
+                    format_backend_cell(
+                        repo_project.tasks_backend.kind.as_str(),
+                        repo_project.tasks_backend.host.as_deref(),
+                        repo_project.tasks_backend.repo.as_deref(),
+                        repo_project.tasks_backend.path.as_deref(),
+                    ),
+                    repo_project
+                        .tasks_backend
+                        .jira_project
+                        .as_deref()
+                        .unwrap_or(""),
+                    repo_project.repo_project_label.as_deref().unwrap_or("")
                 );
             }
         }
@@ -58,19 +100,42 @@ pub fn run(paths: &AppPaths, args: RegisterArgs) -> Result<(), RiptskError> {
     } else {
         None
     };
-    let backend = crate::services::project_detection::register_project_interactive(
+    let repo_project = crate::services::project_detection::register_project_interactive(
         &mut config,
         &DialoguerPrompts,
         ai_backend
             .as_ref()
             .map(|backend| backend as &dyn crate::adapters::ai::AiBackend),
         &cwd,
+        args.repo_project_label,
     )?;
     save_config(paths.config_path().as_std_path(), &config)?;
     crate::ui::success(&format!(
-        "registered {} ({})",
-        backend.name,
-        backend.backend.as_str()
+        "registered {} (vc: {}, tasks: {})",
+        repo_project.name,
+        repo_project.vc_backend.kind.as_str(),
+        repo_project.tasks_backend.kind.as_str()
     ));
     Ok(())
+}
+
+fn format_backend_cell(
+    kind: &str,
+    host: Option<&str>,
+    repo: Option<&str>,
+    path: Option<&str>,
+) -> String {
+    if let Some(path) = path {
+        return format!("{kind}@{path}");
+    }
+    if let Some(repo) = repo {
+        if let Some(host) = host {
+            return format!("{kind}@{host}/{repo}");
+        }
+        return format!("{kind}@{repo}");
+    }
+    if let Some(host) = host {
+        return format!("{kind}@{host}");
+    }
+    kind.to_owned()
 }

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -3,9 +3,9 @@ use crate::cli::{NewArgs, PrCreateArgs, ScopeArgs, StartArgs};
 use crate::commands::{branch, issues, pr};
 use crate::config::{Config, load_config};
 use crate::error::RiptskError;
-use crate::models::Backend;
+use crate::models::BackendKind;
 use crate::paths::AppPaths;
-use crate::services::backend_mapping::resolve_vc_for_backend;
+use crate::services::backend_mapping::build_version_control;
 use crate::services::id_resolution;
 use crate::services::issue_ids;
 use crate::services::project_detection;
@@ -86,35 +86,17 @@ pub async fn run(paths: &AppPaths, mut args: StartArgs) -> Result<(), RiptskErro
     let id = issue.frontmatter.id.clone();
 
     // Check if VC is available for branch/PR
-    let backend = config
-        .backends
+    let repo_project = config
+        .projects
         .iter()
-        .find(|b| b.name == issue.frontmatter.project)
+        .find(|repo_project| repo_project.name == issue.frontmatter.project)
         .ok_or_else(|| RiptskError::Unregistered(issue.frontmatter.project.clone()))?;
 
-    let has_vc = match backend.backend {
-        Backend::Github | Backend::Gitlab => true,
-        Backend::Jira => backend.vc.is_some(),
-        Backend::Local => false,
-    };
+    let has_vc = repo_project.vc_backend.kind != BackendKind::Local;
 
     if !has_vc {
-        if backend.backend == Backend::Jira {
-            crate::ui::info(
-                "No version control backend configured — skipping branch and PR creation.",
-            );
-        }
+        crate::ui::info("No version control backend configured — skipping branch and PR creation.");
         return Ok(());
-    }
-
-    if backend.backend == Backend::Jira {
-        let vc_resolution = resolve_vc_for_backend(backend, &config)?;
-        if vc_resolution.is_none() {
-            crate::ui::info(
-                "No version control backend configured — skipping branch and PR creation.",
-            );
-            return Ok(());
-        }
     }
 
     // Create branch
@@ -142,20 +124,23 @@ async fn should_auto_create_from_changes(
     if !(args.title_pos.is_none() && args.title.is_none() && !args.pick) {
         return false;
     }
-    let Ok(Some(backend)) = project_detection::detect_from_cwd(cwd, config) else {
+    let Ok(Some(repo_project)) = project_detection::detect_from_cwd(cwd, config) else {
         return false;
     };
-    let Ok(Some((provider, vc_backend))) = resolve_vc_for_backend(&backend, config) else {
+    if repo_project.vc_backend.kind == BackendKind::Local {
         return false;
-    };
+    }
     let Ok(repo) = id_resolution::current_repo() else {
+        return false;
+    };
+    let Ok(provider) = build_version_control(&repo_project.vc_backend, &repo_project.name) else {
         return false;
     };
     let git = CliGit::new();
     let Ok(current) = git.current_branch(repo.as_path()) else {
         return false;
     };
-    let repo_name = vc_backend.repo.as_deref().unwrap_or_default();
+    let repo_name = repo_project.vc_backend.repo.as_deref().unwrap_or_default();
     let Ok(default) = crate::ui::spin_on_async("Checking default branch", async {
         provider.default_branch(repo_name).await
     })

--- a/src/commands/sync_cmd.rs
+++ b/src/commands/sync_cmd.rs
@@ -5,7 +5,7 @@ use crate::cli::{
 use crate::config::{Config, load_config};
 use crate::domain::session::SessionState;
 use crate::error::RiptskError;
-use crate::models::{Backend, BackendConfig};
+use crate::models::{BackendKind, RepoProject};
 use crate::paths::AppPaths;
 use crate::services::auto_commit::maybe_auto_commit;
 use crate::services::backend_mapping::build_issue_tracker;
@@ -40,15 +40,15 @@ async fn pull(
 ) -> Result<(), RiptskError> {
     let config = load_config(paths.config_path().as_std_path())?;
     let engine = SyncEngine::new(paths, &config);
-    for backend in resolve_sync_backends(args, &config)? {
-        let provider = build_issue_tracker(backend)?;
-        let pull_ids = resolve_pull_filter_ids(&subargs.ids, backend);
-        let force_ids = resolve_pull_filter_ids(&args.force_pull_ids, backend);
+    for repo_project in resolve_sync_projects(args, &config)? {
+        let provider = build_issue_tracker(repo_project)?;
+        let pull_ids = resolve_pull_filter_ids(&subargs.ids, repo_project);
+        let force_ids = resolve_pull_filter_ids(&args.force_pull_ids, repo_project);
         let summary = crate::ui::spin_on_async(
-            &format!("Pulling issues from {}", backend.name),
+            &format!("Pulling issues from {}", repo_project.name),
             engine.pull(
                 provider.as_ref(),
-                backend,
+                repo_project,
                 args.force,
                 (!pull_ids.is_empty()).then_some(&pull_ids),
                 (!force_ids.is_empty()).then_some(&force_ids),
@@ -56,7 +56,7 @@ async fn pull(
         )
         .await?;
         tracing::info!(
-            backend = %backend.name,
+            repo_project = %repo_project.name,
             created = summary.created.len(),
             updated = summary.updated.len(),
             deleted = summary.deleted.len(),
@@ -109,24 +109,24 @@ async fn push(
         .iter()
         .map(|id| id_resolution::resolve_id(paths, &config, &cwd, id))
         .collect::<Result<Vec<_>, _>>()?;
-    for backend in resolve_sync_backends(args, &config)? {
-        let provider = build_issue_tracker(backend)?;
-        let issue_paths = collect_push_paths(paths, backend, &resolved_ids)?;
+    for repo_project in resolve_sync_projects(args, &config)? {
+        let provider = build_issue_tracker(repo_project)?;
+        let issue_paths = collect_push_paths(paths, repo_project, &resolved_ids)?;
         let summary = if resolved_ids.is_empty() {
             crate::ui::spin_on_async(
-                &format!("Pushing issues to {}", backend.name),
-                engine.push(provider.as_ref(), backend),
+                &format!("Pushing issues to {}", repo_project.name),
+                engine.push(provider.as_ref(), repo_project),
             )
             .await?
         } else {
             crate::ui::spin_on_async(
-                &format!("Pushing issues to {}", backend.name),
-                engine.push_issues(provider.as_ref(), backend, &issue_paths),
+                &format!("Pushing issues to {}", repo_project.name),
+                engine.push_issues(provider.as_ref(), repo_project, &issue_paths),
             )
             .await?
         };
         tracing::info!(
-            backend = %backend.name,
+            repo_project = %repo_project.name,
             created = summary.created.len(),
             updated = summary.updated.len(),
             deleted = summary.deleted.len(),
@@ -161,7 +161,7 @@ async fn push(
             &config,
             &crate::adapters::git::CliGit::new(),
             paths.riptsk_repo.as_std_path(),
-            &format!("riptsk: push local issues to {}", backend.name),
+            &format!("riptsk: push local issues to {}", repo_project.name),
             &file_refs,
         )?;
     }
@@ -170,15 +170,15 @@ async fn push(
 
 fn status(paths: &AppPaths, args: &SyncArgs) -> Result<(), RiptskError> {
     let config = load_config(paths.config_path().as_std_path())?;
-    let backends = resolve_sync_backends(args, &config)?;
-    let backend_names = backends
+    let repo_projects = resolve_sync_projects(args, &config)?;
+    let project_names = repo_projects
         .iter()
-        .map(|backend| backend.name.as_str())
+        .map(|repo_project| repo_project.name.as_str())
         .collect::<HashSet<_>>();
     let summary = SyncEngine::new(paths, &config).status()?;
     let tty = std::io::stdout().is_terminal();
     for id in summary.conflicts {
-        if issue_matches_backend_scope(paths, &id, &backend_names)? {
+        if issue_matches_project_scope(paths, &id, &project_names)? {
             if tty {
                 println!("{} {id}", style("CONFLICT").red().bold());
             } else {
@@ -187,7 +187,7 @@ fn status(paths: &AppPaths, args: &SyncArgs) -> Result<(), RiptskError> {
         }
     }
     for id in summary.creates {
-        if issue_matches_backend_scope(paths, &id, &backend_names)? {
+        if issue_matches_project_scope(paths, &id, &project_names)? {
             if tty {
                 println!("{}   {id}", style("CREATE").green());
             } else {
@@ -196,7 +196,7 @@ fn status(paths: &AppPaths, args: &SyncArgs) -> Result<(), RiptskError> {
         }
     }
     for id in summary.pushes {
-        if issue_matches_backend_scope(paths, &id, &backend_names)? {
+        if issue_matches_project_scope(paths, &id, &project_names)? {
             if tty {
                 println!("{}     {id}", style("PUSH").cyan());
             } else {
@@ -205,7 +205,7 @@ fn status(paths: &AppPaths, args: &SyncArgs) -> Result<(), RiptskError> {
         }
     }
     for key in summary.deletes {
-        if deleted_key_matches_backend_scope(&key, &backends) {
+        if deleted_key_matches_project_scope(&key, &repo_projects) {
             if tty {
                 println!("{}   {key}", style("DELETE").yellow());
             } else {
@@ -216,18 +216,18 @@ fn status(paths: &AppPaths, args: &SyncArgs) -> Result<(), RiptskError> {
     Ok(())
 }
 
-fn resolve_sync_backends<'a>(
+fn resolve_sync_projects<'a>(
     args: &SyncArgs,
     config: &'a Config,
-) -> Result<Vec<&'a BackendConfig>, RiptskError> {
+) -> Result<Vec<&'a RepoProject>, RiptskError> {
     if let Some(name) = args.backend.as_deref() {
-        return Ok(hosted_backends(config)
+        return Ok(hosted_projects(config)
             .into_iter()
-            .filter(|backend| backend.name == name)
+            .filter(|repo_project| repo_project.name == name)
             .collect());
     }
     if args.scope.all_projects {
-        return Ok(hosted_backends(config));
+        return Ok(hosted_projects(config));
     }
     if !args.scope.projects.is_empty() {
         return args
@@ -236,22 +236,22 @@ fn resolve_sync_backends<'a>(
             .iter()
             .map(|project| {
                 config
-                    .backends
+                    .projects
                     .iter()
-                    .find(|backend| backend.name == *project)
+                    .find(|repo_project| repo_project.name == *project)
                     .ok_or_else(|| RiptskError::Unregistered(project.clone()))
             })
             .map(|result| {
-                result.and_then(|backend| {
+                result.and_then(|repo_project| {
                     if matches!(
-                        backend.backend,
-                        Backend::Github | Backend::Gitlab | Backend::Jira
+                        repo_project.tasks_backend.kind,
+                        BackendKind::Github | BackendKind::Gitlab | BackendKind::Jira
                     ) {
-                        Ok(backend)
+                        Ok(repo_project)
                     } else {
                         Err(RiptskError::Config(format!(
                             "sync target must be github, gitlab, or jira: {}",
-                            backend.name
+                            repo_project.name
                         )))
                     }
                 })
@@ -265,12 +265,13 @@ fn resolve_sync_backends<'a>(
             .to_string_lossy()
             .to_string(),
     );
-    if let Ok(Some(backend)) = crate::services::project_detection::detect_from_cwd(&cwd, config)
-        && let Some(candidate) = config.backends.iter().find(|candidate| {
-            candidate.name == backend.name
+    if let Ok(Some(repo_project)) =
+        crate::services::project_detection::detect_from_cwd(&cwd, config)
+        && let Some(candidate) = config.projects.iter().find(|candidate| {
+            candidate.name == repo_project.name
                 && matches!(
-                    candidate.backend,
-                    Backend::Github | Backend::Gitlab | Backend::Jira
+                    candidate.tasks_backend.kind,
+                    BackendKind::Github | BackendKind::Gitlab | BackendKind::Jira
                 )
         })
     {
@@ -282,15 +283,15 @@ fn resolve_sync_backends<'a>(
     ))
 }
 
-fn issue_matches_backend_scope(
+fn issue_matches_project_scope(
     paths: &AppPaths,
     id: &str,
-    backend_names: &HashSet<&str>,
+    project_names: &HashSet<&str>,
 ) -> Result<bool, RiptskError> {
     let path = crate::storage::issue_store::find_issue(paths, id)?;
     match crate::storage::frontmatter::try_load_issue(path.as_std_path()) {
         crate::storage::frontmatter::IssueLoadResult::Ok(issue) => {
-            Ok(backend_names.contains(issue.frontmatter.project.as_str()))
+            Ok(project_names.contains(issue.frontmatter.project.as_str()))
         }
         crate::storage::frontmatter::IssueLoadResult::Conflict { id, .. } => {
             for backup in [
@@ -303,7 +304,7 @@ fn issue_matches_backend_scope(
                 if let crate::storage::frontmatter::IssueLoadResult::Ok(issue) =
                     crate::storage::frontmatter::try_load_issue(backup.as_std_path())
                 {
-                    return Ok(backend_names.contains(issue.frontmatter.project.as_str()));
+                    return Ok(project_names.contains(issue.frontmatter.project.as_str()));
                 }
             }
             Ok(false)
@@ -312,20 +313,20 @@ fn issue_matches_backend_scope(
     }
 }
 
-fn hosted_backends(config: &Config) -> Vec<&BackendConfig> {
+fn hosted_projects(config: &Config) -> Vec<&RepoProject> {
     config
-        .backends
+        .projects
         .iter()
-        .filter(|backend| {
+        .filter(|repo_project| {
             matches!(
-                backend.backend,
-                Backend::Github | Backend::Gitlab | Backend::Jira
+                repo_project.tasks_backend.kind,
+                BackendKind::Github | BackendKind::Gitlab | BackendKind::Jira
             )
         })
         .collect()
 }
 
-fn resolve_pull_filter_ids(ids: &[String], backend: &BackendConfig) -> HashSet<String> {
+fn resolve_pull_filter_ids(ids: &[String], repo_project: &RepoProject) -> HashSet<String> {
     ids.iter()
         .map(|id| {
             if id.contains("--") {
@@ -334,7 +335,7 @@ fn resolve_pull_filter_ids(ids: &[String], backend: &BackendConfig) -> HashSet<S
             if id.chars().all(|character| character.is_ascii_digit()) {
                 let number = id.parse::<u64>().unwrap_or_default();
                 return crate::services::issue_ids::format_id(
-                    &crate::services::issue_ids::effective_key(backend),
+                    &crate::services::issue_ids::effective_key(repo_project),
                     number,
                 );
             }
@@ -345,7 +346,7 @@ fn resolve_pull_filter_ids(ids: &[String], backend: &BackendConfig) -> HashSet<S
 
 fn collect_push_paths(
     paths: &AppPaths,
-    backend: &BackendConfig,
+    repo_project: &RepoProject,
     ids: &[String],
 ) -> Result<Vec<camino::Utf8PathBuf>, RiptskError> {
     if !ids.is_empty() {
@@ -363,7 +364,7 @@ fn collect_push_paths(
                 }
                 frontmatter::IssueLoadResult::Err(error) => return Err(RiptskError::Other(error)),
             };
-            if issue.frontmatter.project == backend.name {
+            if issue.frontmatter.project == repo_project.name {
                 paths_to_push.push(path);
             }
         }
@@ -377,7 +378,7 @@ fn collect_push_paths(
             frontmatter::IssueLoadResult::Conflict { .. } => continue,
             frontmatter::IssueLoadResult::Err(error) => return Err(RiptskError::Other(error)),
         };
-        if issue.frontmatter.project != backend.name {
+        if issue.frontmatter.project != repo_project.name {
             continue;
         }
         paths_to_push.push(path);
@@ -385,13 +386,13 @@ fn collect_push_paths(
     Ok(paths_to_push)
 }
 
-fn deleted_key_matches_backend_scope(key: &str, backends: &[&BackendConfig]) -> bool {
+fn deleted_key_matches_project_scope(key: &str, repo_projects: &[&RepoProject]) -> bool {
     let Some((provider, repo, _issue_id)) = parse_backend_state_key(key) else {
         return false;
     };
-    backends
-        .iter()
-        .any(|backend| provider_name(backend) == provider && backend.repo.as_deref() == Some(repo))
+    repo_projects.iter().any(|repo_project| {
+        provider_name(repo_project) == provider && sync_repo(repo_project).as_deref() == Some(repo)
+    })
 }
 
 fn parse_backend_state_key(key: &str) -> Option<(&str, &str, u64)> {
@@ -400,12 +401,20 @@ fn parse_backend_state_key(key: &str) -> Option<(&str, &str, u64)> {
     Some((provider, repo, issue_id.parse().ok()?))
 }
 
-fn provider_name(backend: &BackendConfig) -> &'static str {
-    match backend.backend {
-        Backend::Github => "github",
-        Backend::Gitlab => "gitlab",
-        Backend::Jira => "jira",
-        Backend::Local => "local",
+fn provider_name(repo_project: &RepoProject) -> &'static str {
+    match repo_project.tasks_backend.kind {
+        BackendKind::Github => "github",
+        BackendKind::Gitlab => "gitlab",
+        BackendKind::Jira => "jira",
+        BackendKind::Local => "local",
+    }
+}
+
+fn sync_repo(repo_project: &RepoProject) -> Option<String> {
+    match repo_project.tasks_backend.kind {
+        BackendKind::Github | BackendKind::Gitlab => repo_project.tasks_backend.repo.clone(),
+        BackendKind::Jira => repo_project.tasks_backend.jira_project.clone(),
+        BackendKind::Local => None,
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,10 @@
 use crate::domain::issue::{IssueState, Priority};
 use crate::error::RiptskError;
 use crate::models::{
-    AiConfig, AiFeatures, BackendConfig, BoardConfig, DefaultsConfig, RecurringDef, SyncConfig,
-    UiConfig,
+    AiConfig, AiFeatures, BackendKind, BoardConfig, DefaultsConfig, RecurringDef, RepoProject,
+    SyncConfig, UiConfig,
 };
-use crate::services::issue_ids;
+use crate::services::{issue_ids, repo_project_label};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fs;
@@ -17,7 +17,7 @@ pub struct Config {
     pub auto_commit: bool,
     pub defaults: DefaultsConfig,
     #[serde(default)]
-    pub backends: Vec<BackendConfig>,
+    pub projects: Vec<RepoProject>,
     #[serde(default)]
     pub boards: Vec<BoardConfig>,
     #[serde(default)]
@@ -41,7 +41,7 @@ pub fn default_config() -> Config {
             assignee: None,
             template: Some("task".into()),
         },
-        backends: Vec::new(),
+        projects: Vec::new(),
         boards: vec![BoardConfig {
             name: "personal".into(),
             statuses: vec![
@@ -106,12 +106,12 @@ pub fn save_config(path: &Path, config: &Config) -> Result<(), RiptskError> {
 pub fn validate_config(config: &mut Config) -> Result<(), RiptskError> {
     // Check explicit `key:` syntax before normalization so users get a clear
     // error that names the offending backend instead of a downstream collision.
-    for backend in &config.backends {
-        if let Some(key) = backend.key.as_deref() {
+    for project in &config.projects {
+        if let Some(key) = project.key.as_deref() {
             issue_ids::validate_explicit_key_syntax(key).map_err(|message| {
                 RiptskError::Config(format!(
-                    "backend '{}' has invalid key: {message}",
-                    backend.name
+                    "RepoProject '{}' has invalid key: {message}",
+                    project.name
                 ))
             })?;
         }
@@ -119,77 +119,67 @@ pub fn validate_config(config: &mut Config) -> Result<(), RiptskError> {
     // Populate every group member with its canonical key so that downstream
     // `effective_key` calls return a stable value regardless of which backend
     // instance they are given.
-    issue_ids::normalize_backend_keys(&mut config.backends)?;
-    issue_ids::validate_no_key_collisions(&config.backends)?;
+    issue_ids::normalize_backend_keys(&mut config.projects)?;
+    issue_ids::validate_no_key_collisions(&config.projects)?;
     require_unique(
-        config.backends.iter().map(|backend| backend.name.as_str()),
-        "duplicate backend name in riptsk.yaml",
+        config.projects.iter().map(|project| project.name.as_str()),
+        "duplicate RepoProject name in riptsk.yaml",
     )?;
     require_unique(
         config.boards.iter().map(|board| board.name.as_str()),
         "duplicate board name in riptsk.yaml",
     )?;
     validate_ai_command(config)?;
-    validate_jira_backends(config)?;
-    validate_vc_references(config)?;
+    validate_projects(config)?;
     Ok(())
 }
 
-/// Validate Jira-specific config requirements:
-/// - `host` is required and must use HTTPS
-/// - `repo` must use `org/PROJECT_KEY` format (must contain `/`)
-fn validate_jira_backends(config: &Config) -> Result<(), RiptskError> {
-    use crate::models::Backend;
-    for backend in &config.backends {
-        if backend.backend != Backend::Jira {
-            continue;
-        }
-        let host = backend.host.as_deref().unwrap_or_default();
-        if host.is_empty() {
+fn validate_projects(config: &Config) -> Result<(), RiptskError> {
+    for repo_project in &config.projects {
+        if repo_project.vc_backend.kind == BackendKind::Jira {
             return Err(RiptskError::Config(format!(
-                "Jira backend '{}' requires a 'host' field (e.g., https://myteam.atlassian.net)",
-                backend.name
+                "RepoProject '{}' has invalid VCBackend: jira is not allowed",
+                repo_project.name
             )));
         }
-        if !host.starts_with("https://") {
-            return Err(RiptskError::Config(format!(
-                "Jira backend '{}' host must start with https:// (got: {})",
-                backend.name, host
-            )));
-        }
-        let repo = backend.repo.as_deref().unwrap_or_default();
-        if repo.is_empty() || !repo.contains('/') {
-            return Err(RiptskError::Config(format!(
-                "Jira backend '{}' requires 'repo' in org/PROJECT_KEY format (got: {:?})",
-                backend.name, backend.repo
-            )));
-        }
-    }
-    Ok(())
-}
 
-/// Validate that `vc` fields reference existing GitHub or GitLab backends.
-/// Prevents referencing nonexistent backends or using Jira/Local as a VC target.
-fn validate_vc_references(config: &Config) -> Result<(), RiptskError> {
-    use crate::models::Backend;
-    for backend in &config.backends {
-        if let Some(ref vc_name) = backend.vc {
-            let vc_backend = config
-                .backends
-                .iter()
-                .find(|b| &b.name == vc_name)
-                .ok_or_else(|| {
-                    RiptskError::Config(format!(
-                        "backend '{}' references vc '{}' which does not exist",
-                        backend.name, vc_name
-                    ))
-                })?;
-            if !matches!(vc_backend.backend, Backend::Github | Backend::Gitlab) {
+        if let Some(label) = repo_project.repo_project_label.as_deref() {
+            repo_project_label::validate(label)?;
+            if repo_project.tasks_backend.kind != BackendKind::Jira {
                 return Err(RiptskError::Config(format!(
-                    "vc '{}' referenced by backend '{}' must be a github or gitlab backend (got: {})",
-                    vc_name,
-                    backend.name,
-                    vc_backend.backend.as_str()
+                    "RepoProject '{}' sets repo_project_label '{}' but its TasksBackend is {:?}; the label is Jira-only and would be silently ignored",
+                    repo_project.name, label, repo_project.tasks_backend.kind
+                )));
+            }
+        }
+
+        if repo_project.tasks_backend.kind == BackendKind::Jira {
+            let host = repo_project
+                .tasks_backend
+                .host
+                .as_deref()
+                .unwrap_or_default();
+            if host.is_empty() {
+                return Err(RiptskError::Config(format!(
+                    "Jira TasksBackend for RepoProject '{}' requires a 'host' field (e.g., https://myteam.atlassian.net)",
+                    repo_project.name
+                )));
+            }
+            if !host.starts_with("https://") {
+                return Err(RiptskError::Config(format!(
+                    "Jira TasksBackend for RepoProject '{}' host must start with https:// (got: {})",
+                    repo_project.name, host
+                )));
+            }
+            let jira_project = repo_project
+                .tasks_backend
+                .jira_project
+                .as_deref()
+                .unwrap_or_default();
+            if jira_project.is_empty() || !jira_project.contains('/') {
+                return Err(RiptskError::Config(format!(
+                    "Jira TasksBackend for RepoProject '{}' requires 'jira_project' in org/PROJECT_KEY format (got: {:?})",
+                    repo_project.name, repo_project.tasks_backend.jira_project
                 )));
             }
         }
@@ -324,7 +314,7 @@ mod tests {
         let config = load_config(std::path::Path::new("tests/fixtures/riptsk.yaml"))
             .expect("load fixture config");
         assert_eq!(config.version, 1);
-        assert_eq!(config.backends.len(), 1);
+        assert_eq!(config.projects.len(), 1);
     }
 
     #[test]
@@ -391,10 +381,14 @@ defaults:
   priority: medium
   assignee: ~
   template: task
-backends:
+projects:
   - name: demo
-    type: github
-    repo: owner/demo
+    vc_backend:
+      type: github
+      repo: owner/demo
+    tasks_backend:
+      type: github
+      repo: owner/demo
     default_board: personal
 boards:
   - name: personal
@@ -420,7 +414,7 @@ recurring: []
         let config = load_config(file.path()).expect("load");
 
         // Normalization populates the in-memory key from the derived default.
-        assert_eq!(config.backends[0].key.as_deref(), Some("DEMO"));
+        assert_eq!(config.projects[0].key.as_deref(), Some("DEMO"));
         // But loading must never rewrite the file on disk.
         let after = fs::read_to_string(file.path()).expect("after");
         assert_eq!(before, after);
@@ -436,14 +430,22 @@ defaults:
   priority: medium
   assignee: ~
   template: task
-backends:
+projects:
   - name: alpha-one
-    type: github
-    repo: owner/alpha
+    vc_backend:
+      type: github
+      repo: owner/alpha
+    tasks_backend:
+      type: github
+      repo: owner/alpha
     default_board: personal
   - name: alpha-two
-    type: github
-    repo: other/alpha
+    vc_backend:
+      type: github
+      repo: other/alpha
+    tasks_backend:
+      type: github
+      repo: other/alpha
     default_board: personal
 boards:
   - name: personal
@@ -467,5 +469,57 @@ recurring: []
 
         let error = load_config(file.path()).expect_err("collision");
         assert!(matches!(error, RiptskError::KeyCollision(_)));
+    }
+
+    #[test]
+    fn load_config_rejects_repo_project_label_on_non_jira_backend() {
+        let file = NamedTempFile::new().expect("temp file");
+        let yaml = r#"version: 1
+defaults:
+  board: personal
+  status: todo
+  priority: medium
+  assignee: ~
+  template: task
+projects:
+  - name: demo
+    vc_backend:
+      type: github
+      repo: owner/demo
+    tasks_backend:
+      type: github
+      repo: owner/demo
+    default_board: personal
+    repo_project_label: proj::demo
+boards:
+  - name: personal
+    statuses: [backlog, todo, in-progress, review, done]
+ui:
+  opener: "nvim -R"
+  tree_depth: 2
+  fzf_opts: "--border"
+ai:
+  enabled: false
+  features:
+    new_body_gen: true
+    triage: true
+    summarize: true
+    ask: true
+sync:
+  conflict_detection: true
+recurring: []
+"#;
+        fs::write(file.path(), yaml).expect("write yaml");
+
+        let error = load_config(file.path()).expect_err("label on non-Jira should fail");
+        match error {
+            RiptskError::Config(msg) => {
+                assert!(
+                    msg.contains("repo_project_label") && msg.contains("Jira-only"),
+                    "unexpected error message: {msg}"
+                );
+            }
+            other => panic!("expected RiptskError::Config, got {other:?}"),
+        }
     }
 }

--- a/src/models/backend.rs
+++ b/src/models/backend.rs
@@ -1,18 +1,17 @@
 use serde::{Deserialize, Serialize};
 
-/// Supported backend types. GitHub and GitLab provide both issue tracking and
-/// version control. Jira is issue-only — use the `vc` field on [`BackendConfig`]
-/// to link a GitHub/GitLab backend for PRs and branches.
+/// Kind of provider — identifies the external service.
+/// Renamed from `Backend` to disambiguate it from the RepoProject config shape.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
-pub enum Backend {
+pub enum BackendKind {
     Github,
     Gitlab,
     Jira,
     Local,
 }
 
-impl Backend {
+impl BackendKind {
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Github => "github",
@@ -23,59 +22,60 @@ impl Backend {
     }
 }
 
-/// Configuration for a single backend entry in `riptsk.yaml`.
-///
-/// A backend can serve as an issue tracker, a version control provider, or both.
-/// The `vc` field allows decoupling: e.g. "issues in Jira, PRs on GitHub".
-///
-/// # Example config
-/// ```yaml
-/// backends:
-///   - name: github-repo
-///     type: github
-///     repo: owner/repo
-///
-///   - name: jira-myteam
-///     type: jira
-///     host: https://myteam.atlassian.net
-///     repo: myteam/PROJ          # org/PROJECT_KEY format
-///     default_issue_type: Task
-///     vc: github-repo            # PRs/branches go to GitHub
-/// ```
+/// Version-control nature of a RepoProject's remote.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct BackendConfig {
-    pub name: String,
+pub struct VCBackendSpec {
     #[serde(rename = "type")]
-    pub backend: Backend,
-    /// Required for Jira (e.g. `https://myteam.atlassian.net`).
-    /// Optional for GitHub (defaults to github.com) and GitLab (defaults to gitlab.com).
+    pub kind: BackendKind,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub host: Option<String>,
-    /// Repository/project identifier. Format varies by backend:
-    /// - GitHub: `owner/repo`
-    /// - GitLab: `group/project`
-    /// - Jira: `org/PROJECT_KEY` (org is user-chosen, PROJECT_KEY is the Jira project)
+    /// GitHub: `owner/repo`. GitLab: `group/project`. Local: unused.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub repo: Option<String>,
+    /// Local VC only: canonical absolute path to the RepoProject directory.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+}
+
+/// Task-tracker nature of a RepoProject's issue backend.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TasksBackendSpec {
+    #[serde(rename = "type")]
+    pub kind: BackendKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
+    /// GitHub: `owner/repo`. GitLab: `group/project`. Local: unused.
+    /// For Jira, use `jira_project` instead of `repo`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
+    /// Jira only: `org/PROJECT_KEY`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub jira_project: Option<String>,
+    /// Jira only: default issue type for creation (e.g. "Task", "Story", "Bug").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_issue_type: Option<String>,
+    /// Local tasks backend only: canonical absolute path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+}
+
+/// A RepoProject — the coding project unit. Corresponds to one registered directory.
+///
+/// When `vc_backend` and `tasks_backend` describe the same remote (e.g. GitHub for
+/// both), the info is duplicated intentionally. Explicit over clever.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RepoProject {
+    pub name: String,
+    pub vc_backend: VCBackendSpec,
+    pub tasks_backend: TasksBackendSpec,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_board: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_org: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub path: Option<String>,
-    /// Name of another backend to use for version control (PRs, branches).
-    /// Must reference a GitHub or GitLab backend. When omitted:
-    /// - GitHub/GitLab backends provide their own VC
-    /// - Jira backends are issue-only (no PR/branch commands)
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub vc: Option<String>,
-    /// Jira-specific: default issue type for creation (e.g. "Task", "Story", "Bug").
-    /// When absent, the type is discovered from Jira's create metadata endpoint.
-    /// Set this to avoid the extra API call on every issue creation.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub default_issue_type: Option<String>,
-    /// Project key used to build issue IDs (`{KEY}--{number}`).
-    /// When absent, the key is derived from `repo`/`name` at runtime.
+    /// Short ID prefix (e.g. `RIPTSK` in `RIPTSK--123`). Derived at registration.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub key: Option<String>,
+    /// Label used to partition a shared Jira project across multiple RepoProjects.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo_project_label: Option<String>,
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -7,7 +7,7 @@ pub mod sync;
 pub mod ui;
 
 pub use ai::{AiConfig, AiFeatures};
-pub use backend::{Backend, BackendConfig};
+pub use backend::{BackendKind, RepoProject, TasksBackendSpec, VCBackendSpec};
 pub use board::BoardConfig;
 pub use defaults::DefaultsConfig;
 pub use recurring::{RecurrenceFrequency, RecurringDef};

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1,6 +1,6 @@
 use crate::config::Config;
 use crate::error::RiptskError;
-use crate::models::BackendConfig;
+use crate::models::RepoProject;
 use crate::services::project_detection;
 use camino::Utf8Path;
 
@@ -34,15 +34,18 @@ pub fn resolve_scope(
         return Ok(ProjectScope::Explicit(projects.to_vec()));
     }
     match project_detection::detect_from_cwd(cwd, config)? {
-        Some(backend) => Ok(ProjectScope::CurrentProject(backend.name)),
+        Some(repo_project) => Ok(ProjectScope::CurrentProject(repo_project.name.clone())),
         None => Err(RiptskError::Config(
             "could not detect project from current directory; use -p <project> or -a to target all projects".into(),
         )),
     }
 }
 
-pub fn lookup_project<'a>(config: &'a Config, name: &str) -> Option<&'a BackendConfig> {
-    config.backends.iter().find(|backend| backend.name == name)
+pub fn lookup_project<'a>(config: &'a Config, name: &str) -> Option<&'a RepoProject> {
+    config
+        .projects
+        .iter()
+        .find(|repo_project| repo_project.name == name)
 }
 
 #[cfg(test)]

--- a/src/services/backend_mapping.rs
+++ b/src/services/backend_mapping.rs
@@ -1,25 +1,16 @@
-//! Backend mapping — builds providers from config, converts between backend and local formats.
-//!
-//! This module is the glue between `BackendConfig` entries and the trait objects
-//! that commands use. It handles:
-//! - Provider construction: `build_issue_tracker()`, `build_version_control()`
-//! - VC resolution: `resolve_vc_for_backend()` (links Jira → GitHub/GitLab for PRs)
-//! - Credential resolution for all backends (env vars → CLI tools → error)
-//! - Data conversion: `backend_to_local()`, `issue_to_upsert()`, `update_issue_from_backend()`
-//! - Git HTTP auth: `resolve_git_auth()` (returns None for Jira — no git involvement)
+//! Backend mapping — builds providers from config and converts between remote and local formats.
 
 use crate::adapters::backend::{
     BackendIssueRecord, BackendIssueUpsert, BackendProvider, IssueTracker, VersionControl,
 };
 use crate::adapters::github::GithubProvider;
 use crate::adapters::gitlab::GitlabProvider;
-use crate::config::Config;
 use crate::domain::issue::{
     GithubIssueMeta, GitlabIssueMeta, IssueDocument, IssueFrontmatter, IssueState, JiraIssueMeta,
     Priority,
 };
 use crate::error::RiptskError;
-use crate::models::{Backend, BackendConfig};
+use crate::models::{BackendKind, RepoProject, VCBackendSpec};
 use crate::services::issue_ids;
 use crate::services::issue_service::{generate_slug, now_utc};
 use std::process::Command;
@@ -44,204 +35,142 @@ impl std::fmt::Display for CredentialSource {
     }
 }
 
-pub fn build_provider_for_backend(
-    backend: &BackendConfig,
+pub fn build_hosted_provider(
+    vc_backend: &VCBackendSpec,
+    display_name: &str,
 ) -> Result<Box<dyn BackendProvider>, RiptskError> {
-    match backend.backend {
-        Backend::Github => {
-            let (token, source) = resolve_github_token(&backend.name)?;
+    match vc_backend.kind {
+        BackendKind::Github => {
+            let (token, source) = resolve_github_token(display_name)?;
             crate::ui::info(&format!(
-                "auth: github backend '{}' using {}",
-                backend.name, source
+                "auth: github VCBackend '{}' using {}",
+                display_name, source
             ));
             Ok(Box::new(GithubProvider::new(&token)?))
         }
-        Backend::Gitlab => {
-            let host = backend
+        BackendKind::Gitlab => {
+            let host = vc_backend
                 .host
                 .as_deref()
                 .unwrap_or("https://gitlab.com")
                 .trim_start_matches("https://")
                 .trim_start_matches("http://")
                 .to_owned();
-            let (token, source) = resolve_gitlab_token(&backend.name, &host)?;
+            let (token, source) = resolve_gitlab_token(display_name, &host)?;
             crate::ui::info(&format!(
-                "auth: gitlab backend '{}' using {}",
-                backend.name, source
+                "auth: gitlab VCBackend '{}' using {}",
+                display_name, source
             ));
             Ok(Box::new(GitlabProvider::new(&host, &token)?))
         }
-        Backend::Jira => Err(RiptskError::Config(
-            "Jira backend uses build_issue_tracker() — see resolve_vc_for_backend()".into(),
-        )),
-        Backend::Local => Err(RiptskError::Config(format!(
-            "backend {} is local-only",
-            backend.name
+        BackendKind::Local => Err(RiptskError::Config(format!(
+            "RepoProject {}: VCBackend is local-only",
+            display_name
+        ))),
+        BackendKind::Jira => Err(RiptskError::Config(format!(
+            "RepoProject {}: VCBackend cannot be jira",
+            display_name
         ))),
     }
 }
 
-/// Build an issue tracker for a backend config.
-/// Works for Github, Gitlab, Jira. Errors for Local.
-pub fn build_issue_tracker(backend: &BackendConfig) -> Result<Box<dyn IssueTracker>, RiptskError> {
-    match backend.backend {
-        Backend::Github => {
-            let (token, source) = resolve_github_token(&backend.name)?;
+pub fn build_issue_tracker(
+    repo_project: &RepoProject,
+) -> Result<Box<dyn IssueTracker>, RiptskError> {
+    match repo_project.tasks_backend.kind {
+        BackendKind::Github => {
+            let (token, source) = resolve_github_token(&repo_project.name)?;
             crate::ui::info(&format!(
-                "auth: github backend '{}' using {}",
-                backend.name, source
+                "auth: github TasksBackend '{}' using {}",
+                repo_project.name, source
             ));
             Ok(Box::new(GithubProvider::new(&token)?))
         }
-        Backend::Gitlab => {
-            let host = backend
+        BackendKind::Gitlab => {
+            let host = repo_project
+                .tasks_backend
                 .host
                 .as_deref()
                 .unwrap_or("https://gitlab.com")
                 .trim_start_matches("https://")
                 .trim_start_matches("http://")
                 .to_owned();
-            let (token, source) = resolve_gitlab_token(&backend.name, &host)?;
+            let (token, source) = resolve_gitlab_token(&repo_project.name, &host)?;
             crate::ui::info(&format!(
-                "auth: gitlab backend '{}' using {}",
-                backend.name, source
+                "auth: gitlab TasksBackend '{}' using {}",
+                repo_project.name, source
             ));
             Ok(Box::new(GitlabProvider::new(&host, &token)?))
         }
-        Backend::Jira => {
-            let host = backend
-                .host
-                .as_deref()
-                .ok_or_else(|| RiptskError::Config("Jira backend requires 'host'".into()))?;
-            let (auth, source) = resolve_jira_credentials(&backend.name, host)?;
+        BackendKind::Jira => {
+            let host =
+                repo_project.tasks_backend.host.as_deref().ok_or_else(|| {
+                    RiptskError::Config("Jira TasksBackend requires 'host'".into())
+                })?;
+            let (auth, source) = resolve_jira_credentials(&repo_project.name, host)?;
             crate::ui::info(&format!(
-                "auth: jira backend '{}' using {}",
-                backend.name, source
+                "auth: jira TasksBackend '{}' using {}",
+                repo_project.name, source
             ));
-            Ok(Box::new(
-                crate::adapters::jira::JiraProvider::with_issue_type(
-                    host,
-                    auth,
-                    backend.default_issue_type.clone(),
-                )?,
-            ))
+            Ok(Box::new(crate::adapters::jira::JiraProvider::with_config(
+                host,
+                auth,
+                repo_project.tasks_backend.default_issue_type.clone(),
+                repo_project.repo_project_label.clone(),
+            )?))
         }
-        Backend::Local => Err(RiptskError::Config(format!(
-            "backend {} is local-only",
-            backend.name
+        BackendKind::Local => Err(RiptskError::Config(format!(
+            "RepoProject {}: TasksBackend is local-only",
+            repo_project.name
         ))),
     }
 }
 
-/// Build a version control provider for a backend config.
-/// Works for Github, Gitlab. Errors for Local.
 pub fn build_version_control(
-    backend: &BackendConfig,
+    vc_backend: &VCBackendSpec,
+    display_name: &str,
 ) -> Result<Box<dyn VersionControl>, RiptskError> {
-    match backend.backend {
-        Backend::Github => {
-            let (token, source) = resolve_github_token(&backend.name)?;
-            crate::ui::info(&format!(
-                "auth: github backend '{}' using {}",
-                backend.name, source
-            ));
-            Ok(Box::new(GithubProvider::new(&token)?))
+    match vc_backend.kind {
+        BackendKind::Github | BackendKind::Gitlab => {
+            let provider = build_hosted_provider(vc_backend, display_name)?;
+            Ok(provider)
         }
-        Backend::Gitlab => {
-            let host = backend
-                .host
-                .as_deref()
-                .unwrap_or("https://gitlab.com")
-                .trim_start_matches("https://")
-                .trim_start_matches("http://")
-                .to_owned();
-            let (token, source) = resolve_gitlab_token(&backend.name, &host)?;
-            crate::ui::info(&format!(
-                "auth: gitlab backend '{}' using {}",
-                backend.name, source
-            ));
-            Ok(Box::new(GitlabProvider::new(&host, &token)?))
-        }
-        Backend::Jira => Err(RiptskError::Config(
-            "Jira is an issue tracker — use the 'vc' config field to link a GitHub/GitLab backend for PRs and branches".into(),
-        )),
-        Backend::Local => Err(RiptskError::Config(format!(
-            "backend {} is local-only — no version control",
-            backend.name
+        BackendKind::Local => Err(RiptskError::Config(format!(
+            "RepoProject {}: VCBackend is local-only",
+            display_name
+        ))),
+        BackendKind::Jira => Err(RiptskError::Config(format!(
+            "RepoProject {}: VCBackend cannot be jira",
+            display_name
         ))),
     }
 }
 
-pub type VcResolution<'a> = Option<(Box<dyn VersionControl>, &'a BackendConfig)>;
-
-/// Resolve the VC provider for a given issue backend.
-/// If backend has `vc` field, look up that backend and build its VC provider.
-/// If backend itself supports VC (Github/Gitlab), use itself.
-/// If neither, return None (issue-only project).
-pub fn resolve_vc_for_backend<'a>(
-    backend: &'a BackendConfig,
-    config: &'a Config,
-) -> Result<VcResolution<'a>, RiptskError> {
-    if let Some(vc_name) = &backend.vc {
-        let vc_backend = config
-            .backends
-            .iter()
-            .find(|b| &b.name == vc_name)
-            .ok_or_else(|| {
-                RiptskError::Config(format!(
-                    "backend '{}' references vc '{}' which does not exist",
-                    backend.name, vc_name
-                ))
-            })?;
-        if !matches!(vc_backend.backend, Backend::Github | Backend::Gitlab) {
-            return Err(RiptskError::Config(format!(
-                "vc '{}' must be a github or gitlab backend",
-                vc_name
-            )));
-        }
-        let provider = build_version_control(vc_backend)?;
-        return Ok(Some((provider, vc_backend)));
-    }
-    // If backend itself supports VC (Github/Gitlab), use itself
-    match backend.backend {
-        Backend::Github | Backend::Gitlab => {
-            let provider = build_version_control(backend)?;
-            Ok(Some((provider, backend)))
-        }
-        _ => Ok(None),
-    }
-}
-
-/// Resolve git HTTP credentials for a backend. Returns `None` for Jira and Local
-/// because Jira has no git involvement — git auth comes from the VC layer separately.
-pub fn resolve_git_auth(backend: &BackendConfig) -> Option<GitHttpAuth> {
-    match backend.backend {
-        Backend::Gitlab => {
-            let host = backend
+pub fn resolve_git_auth(vc_backend: &VCBackendSpec, display_name: &str) -> Option<GitHttpAuth> {
+    match vc_backend.kind {
+        BackendKind::Gitlab => {
+            let host = vc_backend
                 .host
                 .as_deref()
                 .unwrap_or("https://gitlab.com")
                 .trim_start_matches("https://")
                 .trim_start_matches("http://")
                 .to_owned();
-            let (token, _source) = resolve_gitlab_token(&backend.name, &host).ok()?;
+            let (token, _source) = resolve_gitlab_token(display_name, &host).ok()?;
             Some(GitHttpAuth { host, token })
         }
-        Backend::Github => {
-            let (token, _source) = resolve_github_token(&backend.name).ok()?;
+        BackendKind::Github => {
+            let (token, _source) = resolve_github_token(display_name).ok()?;
             Some(GitHttpAuth {
                 host: "github.com".into(),
                 token,
             })
         }
-        Backend::Jira => None,
-        Backend::Local => None,
+        BackendKind::Local | BackendKind::Jira => None,
     }
 }
 
-/// Convert a local `IssueDocument` to a `BackendIssueUpsert` for pushing to a remote backend.
-/// Extracts Jira-specific round-trip metadata (assignee identity) from `JiraIssueMeta`.
-pub fn issue_to_upsert(doc: &IssueDocument) -> BackendIssueUpsert {
+pub fn issue_to_upsert(doc: &IssueDocument, repo_project: &RepoProject) -> BackendIssueUpsert {
     let state = match doc.frontmatter.status {
         IssueState::Done => "closed",
         _ => "open",
@@ -257,12 +186,18 @@ pub fn issue_to_upsert(doc: &IssueDocument) -> BackendIssueUpsert {
         .jira
         .as_ref()
         .and_then(|meta| meta.assignee_name.clone());
+    let mut labels = build_state_labels(&doc.frontmatter.status, &doc.frontmatter.labels);
+    if let Some(label) = effective_repo_project_label(repo_project)
+        && !labels.iter().any(|candidate| candidate == label)
+    {
+        labels.push(label.to_owned());
+    }
     BackendIssueUpsert {
         title: doc.frontmatter.title.clone(),
         body: doc.body.clone(),
         state: Some(state.into()),
         state_reason,
-        labels: build_state_labels(&doc.frontmatter.status, &doc.frontmatter.labels),
+        labels,
         assignees: doc.frontmatter.assignees.clone(),
         milestone_id: doc
             .frontmatter
@@ -284,33 +219,39 @@ pub fn issue_to_upsert(doc: &IssueDocument) -> BackendIssueUpsert {
     }
 }
 
-/// Convert a `BackendIssueRecord` from any backend into a local `IssueDocument`.
-/// Populates the backend-specific metadata (github/gitlab/jira) based on backend type.
-/// For Jira, extracts the issue key from the browse URL and stores assignee identity.
-pub fn backend_to_local(record: &BackendIssueRecord, backend: &BackendConfig) -> IssueDocument {
+pub fn backend_to_local(record: &BackendIssueRecord, repo_project: &RepoProject) -> IssueDocument {
     let state = state_from_backend(record);
-    let issue_id = issue_ids::format_id(&issue_ids::effective_key(backend), record.issue_id);
+    let issue_id = issue_ids::format_id(&issue_ids::effective_key(repo_project), record.issue_id);
+    let task_repo = repo_project.tasks_backend.repo.clone().unwrap_or_default();
+    let jira_project = repo_project
+        .tasks_backend
+        .jira_project
+        .as_deref()
+        .unwrap_or_default();
     IssueDocument {
         frontmatter: IssueFrontmatter {
             id: issue_id.clone(),
             title: record.title.clone(),
             status: state.clone(),
-            board: backend
+            board: repo_project
                 .default_board
                 .clone()
                 .unwrap_or_else(|| "personal".into()),
-            project: backend.name.clone(),
-            org: backend.default_org.clone(),
+            project: repo_project.name.clone(),
+            org: repo_project.default_org.clone(),
             priority: Some(Priority::Medium),
-            labels: labels_without_status(&record.labels),
+            labels: labels_without_status(
+                &record.labels,
+                effective_repo_project_label(repo_project),
+            ),
             assignees: record.assignees.clone(),
             milestone: record.milestone.clone(),
             state_reason: record.state_reason.clone(),
             cycle: None,
             order: Some(1),
-            gitlab: if backend.backend == Backend::Gitlab {
+            gitlab: if repo_project.tasks_backend.kind == BackendKind::Gitlab {
                 Some(GitlabIssueMeta {
-                    repo: backend.repo.clone().unwrap_or_default(),
+                    repo: task_repo.clone(),
                     issue_id: Some(record.issue_id),
                     milestone_id: record.milestone_id,
                     url: Some(record.url.clone()),
@@ -320,9 +261,9 @@ pub fn backend_to_local(record: &BackendIssueRecord, backend: &BackendConfig) ->
             } else {
                 None
             },
-            github: if backend.backend == Backend::Github {
+            github: if repo_project.tasks_backend.kind == BackendKind::Github {
                 Some(GithubIssueMeta {
-                    repo: backend.repo.clone().unwrap_or_default(),
+                    repo: task_repo,
                     issue_id: Some(record.issue_id),
                     node_id: record.node_id.clone(),
                     milestone_id: record.milestone_id,
@@ -333,13 +274,11 @@ pub fn backend_to_local(record: &BackendIssueRecord, backend: &BackendConfig) ->
             } else {
                 None
             },
-            jira: if backend.backend == Backend::Jira {
+            jira: if repo_project.tasks_backend.kind == BackendKind::Jira {
                 let issue_key = extract_jira_key_from_url(&record.url);
                 Some(JiraIssueMeta {
-                    project_key: crate::adapters::jira::JiraProvider::project_key(
-                        backend.repo.as_deref().unwrap_or_default(),
-                    )
-                    .to_owned(),
+                    project_key: crate::adapters::jira::JiraProvider::project_key(jira_project)
+                        .to_owned(),
                     issue_key,
                     issue_id: Some(record.issue_id),
                     url: Some(record.url.clone()),
@@ -372,8 +311,6 @@ pub fn backend_to_local(record: &BackendIssueRecord, backend: &BackendConfig) ->
     }
 }
 
-/// Copy fields that exist only locally from `source` onto `target`, so they
-/// do not create false diffs when materializing a remote-only document.
 pub fn copy_local_only_fields(target: &mut IssueFrontmatter, source: &IssueFrontmatter) {
     target.pr_url = source.pr_url.clone();
     target.pr_number = source.pr_number;
@@ -399,12 +336,13 @@ pub fn build_state_labels(state: &IssueState, labels: &[String]) -> Vec<String> 
 pub fn update_issue_from_backend(
     issue: &mut IssueDocument,
     record: &BackendIssueRecord,
-    backend: &BackendConfig,
+    repo_project: &RepoProject,
 ) {
     let state = state_from_backend(record);
     issue.frontmatter.title = record.title.clone();
     issue.frontmatter.status = state.clone();
-    issue.frontmatter.labels = labels_without_status(&record.labels);
+    issue.frontmatter.labels =
+        labels_without_status(&record.labels, effective_repo_project_label(repo_project));
     issue.frontmatter.assignees = record.assignees.clone();
     issue.frontmatter.milestone = record.milestone.clone();
     issue.frontmatter.state_reason = record.state_reason.clone();
@@ -418,10 +356,10 @@ pub fn update_issue_from_backend(
     issue.frontmatter.lock_reason = record.lock_reason.clone();
     issue.frontmatter.id_slug = Some(generate_slug(&issue.frontmatter.id, &record.title));
     issue.body = record.body.clone().unwrap_or_default();
-    match backend.backend {
-        Backend::Github => {
+    match repo_project.tasks_backend.kind {
+        BackendKind::Github => {
             issue.frontmatter.github = Some(GithubIssueMeta {
-                repo: backend.repo.clone().unwrap_or_default(),
+                repo: repo_project.tasks_backend.repo.clone().unwrap_or_default(),
                 issue_id: Some(record.issue_id),
                 node_id: record.node_id.clone(),
                 milestone_id: record.milestone_id,
@@ -430,9 +368,9 @@ pub fn update_issue_from_backend(
                 last_pushed_state: Some(state),
             });
         }
-        Backend::Gitlab => {
+        BackendKind::Gitlab => {
             issue.frontmatter.gitlab = Some(GitlabIssueMeta {
-                repo: backend.repo.clone().unwrap_or_default(),
+                repo: repo_project.tasks_backend.repo.clone().unwrap_or_default(),
                 issue_id: Some(record.issue_id),
                 milestone_id: record.milestone_id,
                 url: Some(record.url.clone()),
@@ -440,11 +378,15 @@ pub fn update_issue_from_backend(
                 last_pushed_state: Some(state),
             });
         }
-        Backend::Jira => {
+        BackendKind::Jira => {
             let issue_key = extract_jira_key_from_url(&record.url);
             issue.frontmatter.jira = Some(JiraIssueMeta {
                 project_key: crate::adapters::jira::JiraProvider::project_key(
-                    backend.repo.as_deref().unwrap_or_default(),
+                    repo_project
+                        .tasks_backend
+                        .jira_project
+                        .as_deref()
+                        .unwrap_or_default(),
                 )
                 .to_owned(),
                 issue_key,
@@ -457,7 +399,7 @@ pub fn update_issue_from_backend(
                 assignee_name: record.assignee_name.clone(),
             });
         }
-        Backend::Local => {}
+        BackendKind::Local => {}
     }
 }
 
@@ -501,7 +443,6 @@ fn run_gh_auth_token(host: &str) -> Result<String, String> {
         }
         Err(error) => return Err(format!("'gh' failed to run: {error}")),
     };
-
     if !output.status.success() {
         let status = output
             .status
@@ -510,12 +451,10 @@ fn run_gh_auth_token(host: &str) -> Result<String, String> {
             .unwrap_or_else(|| "unknown".into());
         return Err(format!("'gh auth token' exited with status {status}"));
     }
-
     let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
     if stdout.is_empty() {
         return Err("'gh auth token' returned empty output (expected raw token on stdout)".into());
     }
-
     Ok(stdout)
 }
 
@@ -530,7 +469,6 @@ fn run_glab_auth_token(host: &str) -> Result<String, String> {
         }
         Err(error) => return Err(format!("'glab' failed to run: {error}")),
     };
-
     if !output.status.success() {
         let status = output
             .status
@@ -539,12 +477,10 @@ fn run_glab_auth_token(host: &str) -> Result<String, String> {
             .unwrap_or_else(|| "unknown".into());
         return Err(format!("'glab auth status' exited with status {status}"));
     }
-
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
     if stderr.trim().is_empty() {
         return Err("'glab auth status' produced no output on stderr".into());
     }
-
     parse_glab_token(&stderr).ok_or_else(|| {
         "glab output did not contain expected 'Token found:' line (glab may have changed its output format)".into()
     })
@@ -564,18 +500,17 @@ fn parse_glab_token(stderr_output: &str) -> Option<String> {
     })
 }
 
-fn resolve_github_token(backend_name: &str) -> Result<(String, CredentialSource), RiptskError> {
+fn resolve_github_token(display_name: &str) -> Result<(String, CredentialSource), RiptskError> {
     if let Some(token) = non_empty_env("GITHUB_TOKEN") {
         return Ok((token, CredentialSource::EnvVar("GITHUB_TOKEN")));
     }
     if let Some(token) = non_empty_env("GH_TOKEN") {
         return Ok((token, CredentialSource::EnvVar("GH_TOKEN")));
     }
-
     match run_gh_auth_token("github.com") {
         Ok(token) => Ok((token, CredentialSource::CliTool("gh auth token"))),
         Err(reason) => Err(RiptskError::Auth(format!(
-            "GitHub authentication failed for backend '{backend_name}'\n\n\
+            "GitHub authentication failed for VC/Tasks backend '{display_name}'\n\n\
 Tried: GITHUB_TOKEN, GH_TOKEN, gh auth token\n\n\
 {reason}\n\n\
 To fix, do one of:\n\
@@ -587,20 +522,19 @@ To fix, do one of:\n\
 }
 
 fn resolve_gitlab_token(
-    backend_name: &str,
+    display_name: &str,
     host: &str,
 ) -> Result<(String, CredentialSource), RiptskError> {
     if let Some(token) = non_empty_env("GITLAB_TOKEN") {
         return Ok((token, CredentialSource::EnvVar("GITLAB_TOKEN")));
     }
-
     match run_glab_auth_token(host) {
         Ok(token) => Ok((
             token,
             CredentialSource::CliTool("glab auth status --show-token"),
         )),
         Err(reason) => Err(RiptskError::Auth(format!(
-            "GitLab authentication failed for backend '{backend_name}' (host: {host})\n\n\
+            "GitLab authentication failed for VC/Tasks backend '{display_name}' (host: {host})\n\n\
 Tried: GITLAB_TOKEN, glab auth status --show-token\n\n\
 {reason}\n\n\
 To fix, do one of:\n\
@@ -610,18 +544,11 @@ To fix, do one of:\n\
     }
 }
 
-/// Resolve Jira credentials following the same pattern as GitHub/GitLab:
-/// 1. `JIRA_API_TOKEN` + `JIRA_EMAIL` → Cloud basic auth (base64 `email:token`)
-/// 2. `JIRA_API_TOKEN` alone → Server/DC PAT auth (Bearer token)
-/// 3. `jira-cli-go` config + system keychain → auto-detect Cloud vs Server
-/// 4. Error with actionable guidance
 fn resolve_jira_credentials(
-    backend_name: &str,
+    display_name: &str,
     host: &str,
 ) -> Result<(crate::adapters::jira::JiraAuth, CredentialSource), RiptskError> {
     use crate::adapters::jira::JiraAuth;
-
-    // 1. Check JIRA_API_TOKEN + JIRA_EMAIL (Cloud basic auth)
     if let Some(token) = non_empty_env("JIRA_API_TOKEN") {
         if let Some(email) = non_empty_env("JIRA_EMAIL") {
             return Ok((
@@ -629,14 +556,11 @@ fn resolve_jira_credentials(
                 CredentialSource::EnvVar("JIRA_API_TOKEN+JIRA_EMAIL"),
             ));
         }
-        // Token without email = PAT auth (Server/DC)
         return Ok((
             JiraAuth::Pat(token),
             CredentialSource::EnvVar("JIRA_API_TOKEN"),
         ));
     }
-
-    // 2. Try jira-cli-go config + system keychain
     match run_jira_cli_go_auth(host) {
         Ok((login, token, is_bearer)) => {
             let auth = if is_bearer {
@@ -647,31 +571,19 @@ fn resolve_jira_credentials(
                     token,
                 }
             };
-            return Ok((auth, CredentialSource::CliTool("jira-cli-go keychain")));
+            Ok((auth, CredentialSource::CliTool("jira-cli-go keychain")))
         }
-        Err(_reason) => {}
-    }
-
-    // 3. All failed
-    Err(RiptskError::Auth(format!(
-        "Jira authentication failed for backend '{backend_name}' (host: {host})\n\n\
+        Err(_) => Err(RiptskError::Auth(format!(
+            "Jira authentication failed for TasksBackend '{display_name}' (host: {host})\n\n\
 Tried: JIRA_API_TOKEN, jira-cli-go keychain\n\n\
 To fix, do one of:\n\
   • export JIRA_API_TOKEN=<token> JIRA_EMAIL=<email>\n\
   • brew install ankitpokhrel/jira-cli/jira-cli && jira init"
-    )))
+        ))),
+    }
 }
 
-/// Read credentials from `jira-cli-go`'s config and system keychain.
-///
-/// `jira-cli-go` (~3.8k GitHub stars) is the de facto Jira CLI. `jira init`
-/// stores config at `~/.config/.jira/.config.yml` (server URL, login email)
-/// and the API token in the system keychain (macOS Keychain, GNOME Keyring,
-/// Windows Credential Manager) under service="jira-cli".
-///
-/// Returns `(login, token, is_bearer)`. `is_bearer` is true for Server/DC PAT auth.
 fn run_jira_cli_go_auth(host: &str) -> Result<(String, String, bool), String> {
-    // Parse ~/.config/.jira/.config.yml
     let config_path = dirs_jira_cli_config();
     let content = std::fs::read_to_string(&config_path)
         .map_err(|e| format!("cannot read jira-cli config at {config_path}: {e}"))?;
@@ -686,15 +598,12 @@ fn run_jira_cli_go_auth(host: &str) -> Result<(String, String, bool), String> {
 
     let config: JiraCliGoConfig =
         serde_yaml_ng::from_str(&content).map_err(|e| format!("invalid jira-cli config: {e}"))?;
-
     let server = config
         .server
         .ok_or_else(|| "jira-cli config missing 'server' field".to_string())?;
     let login = config
         .login
         .ok_or_else(|| "jira-cli config missing 'login' field".to_string())?;
-
-    // Validate the server matches the expected host
     let server_trimmed = server.trim_end_matches('/');
     let host_trimmed = host.trim_end_matches('/');
     if !server_trimmed.eq_ignore_ascii_case(host_trimmed) {
@@ -702,22 +611,17 @@ fn run_jira_cli_go_auth(host: &str) -> Result<(String, String, bool), String> {
             "jira-cli config server '{server}' does not match expected host '{host}'"
         ));
     }
-
-    // Read API token from system keychain
     let entry =
         keyring::Entry::new("jira-cli", &login).map_err(|e| format!("keyring error: {e}"))?;
     let token = entry
         .get_password()
         .map_err(|e| format!("cannot read jira-cli token from keychain: {e}"))?;
-
-    // Detect auth type: "bearer" means Server/DC PAT, otherwise Cloud basic
     let auth_type_env = std::env::var("JIRA_AUTH_TYPE").ok();
     let is_bearer = config
         .auth_type
         .as_deref()
         .or(auth_type_env.as_deref())
-        .is_some_and(|t| t.eq_ignore_ascii_case("bearer"));
-
+        .is_some_and(|kind| kind.eq_ignore_ascii_case("bearer"));
     if is_bearer {
         Ok((login, token, true))
     } else {
@@ -754,12 +658,6 @@ fn state_from_backend(record: &BackendIssueRecord) -> IssueState {
     IssueState::Backlog
 }
 
-/// Drop `state_reason` values that are invalid for the target state.
-///
-/// GitHub allows `completed` / `not_planned` / `duplicate` when closing
-/// and `reopened` when opening. Sending a mismatched reason triggers a
-/// 422 validation error. Jira resolutions map through the same values:
-/// "Done" ↔ "completed", "Won't Do" ↔ "not_planned", "Duplicate" ↔ "duplicate".
 fn sanitize_state_reason(state: &str, reason: Option<&str>) -> Option<String> {
     let reason = reason?;
     let valid = match state {
@@ -770,15 +668,26 @@ fn sanitize_state_reason(state: &str, reason: Option<&str>) -> Option<String> {
     if valid { Some(reason.to_owned()) } else { None }
 }
 
-/// Extract the Jira issue key from a browse URL like `https://host/browse/PROJ-123`.
 fn extract_jira_key_from_url(url: &str) -> Option<String> {
-    url.rsplit('/').next().map(|s| s.to_owned())
+    url.rsplit('/').next().map(|value| value.to_owned())
 }
 
-fn labels_without_status(labels: &[String]) -> Vec<String> {
+/// Return the RepoProject's partition label only when it is meaningful for the
+/// active tasks backend. Today only Jira uses label-partitioning, so non-Jira
+/// tasks backends ignore the label even if one is stored on the RepoProject.
+pub fn effective_repo_project_label(repo_project: &RepoProject) -> Option<&str> {
+    if repo_project.tasks_backend.kind == BackendKind::Jira {
+        repo_project.repo_project_label.as_deref()
+    } else {
+        None
+    }
+}
+
+fn labels_without_status(labels: &[String], repo_project_label: Option<&str>) -> Vec<String> {
     labels
         .iter()
         .filter(|label| !label.starts_with("status::"))
+        .filter(|label| Some(label.as_str()) != repo_project_label)
         .cloned()
         .collect()
 }
@@ -786,11 +695,11 @@ fn labels_without_status(labels: &[String]) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        copy_local_only_fields, non_empty_env, parse_glab_token, resolve_git_auth,
+        copy_local_only_fields, issue_to_upsert, non_empty_env, parse_glab_token, resolve_git_auth,
         sanitize_state_reason,
     };
-    use crate::domain::issue::{IssueFrontmatter, IssueState, Priority};
-    use crate::models::{Backend, BackendConfig};
+    use crate::domain::issue::{IssueDocument, IssueFrontmatter, IssueState, Priority};
+    use crate::models::{BackendKind, RepoProject, TasksBackendSpec, VCBackendSpec};
     use std::sync::{LazyLock, Mutex};
 
     static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
@@ -803,7 +712,6 @@ mod tests {
     impl EnvGuard {
         fn unset(name: &'static str) -> Self {
             let original = std::env::var(name).ok();
-            // SAFETY: these tests serialize environment mutation with ENV_LOCK.
             unsafe {
                 std::env::remove_var(name);
             }
@@ -812,7 +720,6 @@ mod tests {
 
         fn set(name: &'static str, value: &str) -> Self {
             let original = std::env::var(name).ok();
-            // SAFETY: these tests serialize environment mutation with ENV_LOCK.
             unsafe {
                 std::env::set_var(name, value);
             }
@@ -823,144 +730,38 @@ mod tests {
     impl Drop for EnvGuard {
         fn drop(&mut self) {
             match &self.original {
-                Some(value) => {
-                    // SAFETY: these tests serialize environment mutation with ENV_LOCK.
-                    unsafe {
-                        std::env::set_var(self.name, value);
-                    }
-                }
-                None => {
-                    // SAFETY: these tests serialize environment mutation with ENV_LOCK.
-                    unsafe {
-                        std::env::remove_var(self.name);
-                    }
-                }
+                Some(value) => unsafe {
+                    std::env::set_var(self.name, value);
+                },
+                None => unsafe {
+                    std::env::remove_var(self.name);
+                },
             }
         }
     }
 
-    #[test]
-    fn non_empty_env_returns_none_for_unset_var() {
-        let _lock = ENV_LOCK.lock().expect("env lock");
-        let _guard = EnvGuard::unset("RIPTSK_TEST_NON_EMPTY_ENV");
-
-        assert_eq!(non_empty_env("RIPTSK_TEST_NON_EMPTY_ENV"), None);
-    }
-
-    #[test]
-    fn non_empty_env_returns_none_for_empty_string() {
-        let _lock = ENV_LOCK.lock().expect("env lock");
-        let _guard = EnvGuard::set("RIPTSK_TEST_NON_EMPTY_ENV", "");
-
-        assert_eq!(non_empty_env("RIPTSK_TEST_NON_EMPTY_ENV"), None);
-    }
-
-    #[test]
-    fn non_empty_env_returns_none_for_whitespace_only() {
-        let _lock = ENV_LOCK.lock().expect("env lock");
-        let _guard = EnvGuard::set("RIPTSK_TEST_NON_EMPTY_ENV", "   \t  ");
-
-        assert_eq!(non_empty_env("RIPTSK_TEST_NON_EMPTY_ENV"), None);
-    }
-
-    #[test]
-    fn non_empty_env_returns_some_for_valid_value() {
-        let _lock = ENV_LOCK.lock().expect("env lock");
-        let _guard = EnvGuard::set("RIPTSK_TEST_NON_EMPTY_ENV", "token-123");
-
-        assert_eq!(
-            non_empty_env("RIPTSK_TEST_NON_EMPTY_ENV"),
-            Some("token-123".into())
-        );
-    }
-
-    #[test]
-    fn parse_glab_token_extracts_token_from_multiline_output() {
-        let stderr_output = "gitlab.suse.de\n  ✓ Logged in to gitlab.suse.de as user\n  ✓ Token found: glpat-xxxx\n  ✓ REST API Endpoint: https://gitlab.suse.de/api/v4/";
-
-        assert_eq!(parse_glab_token(stderr_output), Some("glpat-xxxx".into()));
-    }
-
-    #[test]
-    fn parse_glab_token_returns_none_without_token_line() {
-        let stderr_output = "gitlab.com\n  ✓ Logged in\n  ✓ API calls: 123";
-
-        assert_eq!(parse_glab_token(stderr_output), None);
-    }
-
-    #[test]
-    fn parse_glab_token_handles_plain_token_found_line() {
-        let stderr_output = "gitlab.com\nToken found: glpat-xxxx";
-
-        assert_eq!(parse_glab_token(stderr_output), Some("glpat-xxxx".into()));
-    }
-
-    #[test]
-    fn parse_glab_token_falls_back_to_token_prefix() {
-        let stderr_output = "gitlab.com\nToken: glpat-xxxx";
-
-        assert_eq!(parse_glab_token(stderr_output), Some("glpat-xxxx".into()));
-    }
-
-    #[test]
-    fn parse_glab_token_returns_none_for_empty_token_value() {
-        let stderr_output = "Token found:  ";
-
-        assert_eq!(parse_glab_token(stderr_output), None);
-    }
-
-    #[test]
-    fn resolve_git_auth_returns_none_for_local_backend() {
-        let backend = BackendConfig {
-            name: "local".into(),
-            backend: Backend::Local,
-            host: None,
-            repo: None,
-            default_board: None,
+    fn repo_project(kind: BackendKind, label: Option<&str>) -> RepoProject {
+        RepoProject {
+            name: "demo".into(),
+            vc_backend: VCBackendSpec {
+                kind: BackendKind::Github,
+                host: None,
+                repo: Some("owner/repo".into()),
+                path: None,
+            },
+            tasks_backend: TasksBackendSpec {
+                kind,
+                host: Some("https://jira.example".into()),
+                repo: Some("owner/repo".into()),
+                jira_project: Some("org/PROJ".into()),
+                default_issue_type: None,
+                path: None,
+            },
+            default_board: Some("personal".into()),
             default_org: None,
-            path: None,
-            vc: None,
-            default_issue_type: None,
-            key: None,
-        };
-
-        assert!(resolve_git_auth(&backend).is_none());
-    }
-
-    #[test]
-    fn copy_local_only_fields_copies_all_fields() {
-        let source = frontmatter_fixture("SRC", "Source title");
-        let mut target = frontmatter_fixture("DST", "Target title");
-        target.pr_url = None;
-        target.pr_number = None;
-        target.branch = None;
-        target.order = Some(1);
-        target.recurring = None;
-        target.cycle = None;
-        target.board = "personal".into();
-        target.org = None;
-        target.priority = Some(Priority::Medium);
-        let original_title = target.title.clone();
-        let original_status = target.status.clone();
-        let original_labels = target.labels.clone();
-
-        copy_local_only_fields(&mut target, &source);
-
-        assert_eq!(
-            target.pr_url.as_deref(),
-            Some("https://example.invalid/pulls/42")
-        );
-        assert_eq!(target.pr_number, Some(42));
-        assert_eq!(target.branch.as_deref(), Some("feature/42"));
-        assert_eq!(target.order, Some(7));
-        assert_eq!(target.recurring.as_deref(), Some("weekly-42"));
-        assert_eq!(target.cycle.as_deref(), Some("2026-W13"));
-        assert_eq!(target.board, "ops");
-        assert_eq!(target.org.as_deref(), Some("eng"));
-        assert_eq!(target.priority, Some(Priority::High));
-        assert_eq!(target.title, original_title);
-        assert_eq!(target.status, original_status);
-        assert_eq!(target.labels, original_labels);
+            key: Some("DEMO".into()),
+            repo_project_label: label.map(str::to_owned),
+        }
     }
 
     fn frontmatter_fixture(id: &str, title: &str) -> IssueFrontmatter {
@@ -999,220 +800,98 @@ mod tests {
     }
 
     #[test]
+    fn non_empty_env_returns_none_for_unset_var() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _guard = EnvGuard::unset("RIPTSK_TEST_NON_EMPTY_ENV");
+        assert_eq!(non_empty_env("RIPTSK_TEST_NON_EMPTY_ENV"), None);
+    }
+
+    #[test]
+    fn parse_glab_token_extracts_token_from_multiline_output() {
+        let stderr_output = "gitlab.suse.de\n  ✓ Logged in to gitlab.suse.de as user\n  ✓ Token found: glpat-xxxx\n  ✓ REST API Endpoint: https://gitlab.suse.de/api/v4/";
+        assert_eq!(parse_glab_token(stderr_output), Some("glpat-xxxx".into()));
+    }
+
+    #[test]
+    fn resolve_git_auth_returns_none_for_local_backend() {
+        let vc_backend = VCBackendSpec {
+            kind: BackendKind::Local,
+            host: None,
+            repo: None,
+            path: None,
+        };
+        assert!(resolve_git_auth(&vc_backend, "local").is_none());
+    }
+
+    #[test]
+    fn copy_local_only_fields_copies_all_fields() {
+        let source = frontmatter_fixture("SRC", "Source title");
+        let mut target = frontmatter_fixture("DST", "Target title");
+        target.pr_url = None;
+        copy_local_only_fields(&mut target, &source);
+        assert_eq!(
+            target.pr_url.as_deref(),
+            Some("https://example.invalid/pulls/42")
+        );
+        assert_eq!(target.pr_number, Some(42));
+        assert_eq!(target.branch.as_deref(), Some("feature/42"));
+    }
+
+    #[test]
     fn sanitize_state_reason_drops_reopened_when_closing() {
         assert_eq!(sanitize_state_reason("closed", Some("reopened")), None);
     }
 
     #[test]
-    fn sanitize_state_reason_allows_completed_when_closing() {
-        assert_eq!(
-            sanitize_state_reason("closed", Some("completed")),
-            Some("completed".into())
+    fn issue_to_upsert_injects_repo_project_label() {
+        let repo_project = repo_project(BackendKind::Jira, Some("proj::repo-a"));
+        let issue = IssueDocument {
+            frontmatter: frontmatter_fixture("DEMO--1", "Title"),
+            body: "Body".into(),
+            remote_section: None,
+        };
+        let upsert = issue_to_upsert(&issue, &repo_project);
+        assert!(upsert.labels.contains(&"proj::repo-a".to_string()));
+        assert!(upsert.labels.iter().any(|label| label == "status::todo"));
+    }
+
+    #[test]
+    fn issue_to_upsert_skips_label_for_non_jira_backend() {
+        // Auto-registration may populate `repo_project_label` on every RepoProject
+        // (not just Jira), but label injection is strictly a Jira partitioning
+        // feature. GitHub/GitLab upserts must not get an extra project label.
+        let repo_project = repo_project(BackendKind::Github, Some("proj::repo-a"));
+        let issue = IssueDocument {
+            frontmatter: frontmatter_fixture("DEMO--1", "Title"),
+            body: "Body".into(),
+            remote_section: None,
+        };
+        let upsert = issue_to_upsert(&issue, &repo_project);
+        assert!(
+            !upsert.labels.iter().any(|label| label == "proj::repo-a"),
+            "GitHub upsert labels should not contain repo_project_label: {:?}",
+            upsert.labels
         );
     }
 
     #[test]
-    fn sanitize_state_reason_allows_not_planned_when_closing() {
+    fn issue_to_upsert_dedupes_repo_project_label() {
+        let repo_project = repo_project(BackendKind::Jira, Some("proj::repo-a"));
+        let mut frontmatter = frontmatter_fixture("DEMO--1", "Title");
+        frontmatter.labels.push("proj::repo-a".into());
+        let issue = IssueDocument {
+            frontmatter,
+            body: "Body".into(),
+            remote_section: None,
+        };
+        let upsert = issue_to_upsert(&issue, &repo_project);
         assert_eq!(
-            sanitize_state_reason("closed", Some("not_planned")),
-            Some("not_planned".into())
+            upsert
+                .labels
+                .iter()
+                .filter(|label| *label == "proj::repo-a")
+                .count(),
+            1
         );
-    }
-
-    #[test]
-    fn sanitize_state_reason_allows_duplicate_when_closing() {
-        assert_eq!(
-            sanitize_state_reason("closed", Some("duplicate")),
-            Some("duplicate".into())
-        );
-    }
-
-    #[test]
-    fn sanitize_state_reason_drops_completed_when_opening() {
-        assert_eq!(sanitize_state_reason("open", Some("completed")), None);
-    }
-
-    #[test]
-    fn sanitize_state_reason_allows_reopened_when_opening() {
-        assert_eq!(
-            sanitize_state_reason("open", Some("reopened")),
-            Some("reopened".into())
-        );
-    }
-
-    #[test]
-    fn sanitize_state_reason_passes_through_none() {
-        assert_eq!(sanitize_state_reason("closed", None), None);
-    }
-
-    #[test]
-    fn resolve_git_auth_returns_none_for_jira_backend() {
-        let backend = BackendConfig {
-            name: "jira-test".into(),
-            backend: Backend::Jira,
-            host: Some("https://test.atlassian.net".into()),
-            repo: Some("org/PROJ".into()),
-            default_board: None,
-            default_org: None,
-            path: None,
-            vc: None,
-            default_issue_type: None,
-            key: None,
-        };
-
-        assert!(resolve_git_auth(&backend).is_none());
-    }
-
-    #[test]
-    fn resolve_jira_credentials_with_env_vars() {
-        let _lock = ENV_LOCK.lock().expect("env lock");
-        let _token = EnvGuard::set("JIRA_API_TOKEN", "test-token");
-        let _email = EnvGuard::set("JIRA_EMAIL", "test@example.com");
-
-        let result = super::resolve_jira_credentials("test-backend", "https://test.atlassian.net");
-        assert!(result.is_ok());
-        let (auth, source) = result.unwrap();
-        match auth {
-            crate::adapters::jira::JiraAuth::Basic { email, token } => {
-                assert_eq!(email, "test@example.com");
-                assert_eq!(token, "test-token");
-            }
-            _ => panic!("expected Basic auth"),
-        }
-        assert_eq!(source.to_string(), "JIRA_API_TOKEN+JIRA_EMAIL");
-    }
-
-    #[test]
-    fn resolve_jira_credentials_pat_without_email() {
-        let _lock = ENV_LOCK.lock().expect("env lock");
-        let _token = EnvGuard::set("JIRA_API_TOKEN", "pat-token");
-        let _email = EnvGuard::unset("JIRA_EMAIL");
-
-        let result = super::resolve_jira_credentials("test-backend", "https://test.atlassian.net");
-        assert!(result.is_ok());
-        let (auth, source) = result.unwrap();
-        match auth {
-            crate::adapters::jira::JiraAuth::Pat(token) => {
-                assert_eq!(token, "pat-token");
-            }
-            _ => panic!("expected PAT auth"),
-        }
-        assert_eq!(source.to_string(), "JIRA_API_TOKEN");
-    }
-
-    #[test]
-    fn resolve_jira_credentials_fails_without_any() {
-        let _lock = ENV_LOCK.lock().expect("env lock");
-        let _token = EnvGuard::unset("JIRA_API_TOKEN");
-        let _email = EnvGuard::unset("JIRA_EMAIL");
-
-        let result = super::resolve_jira_credentials("test-backend", "https://test.atlassian.net");
-        assert!(result.is_err());
-        let error = result.unwrap_err().to_string();
-        assert!(error.contains("Jira authentication failed"));
-        assert!(error.contains("JIRA_API_TOKEN"));
-    }
-
-    #[test]
-    fn resolve_vc_for_jira_without_vc_returns_none() {
-        let backend = BackendConfig {
-            name: "jira-test".into(),
-            backend: Backend::Jira,
-            host: Some("https://test.atlassian.net".into()),
-            repo: Some("org/PROJ".into()),
-            default_board: None,
-            default_org: None,
-            path: None,
-            vc: None,
-            default_issue_type: None,
-            key: None,
-        };
-        let config = crate::config::Config {
-            backends: vec![backend.clone()],
-            ..crate::config::default_config()
-        };
-
-        let result = super::resolve_vc_for_backend(&backend, &config);
-        // Will fail at auth (no credentials), but that's expected in tests.
-        // The important thing is the logic path.
-        // For a test with no credentials available, the resolve will error.
-        // Let's just test the None case with a Jira backend that has no vc field.
-        // resolve_vc_for_backend checks backend.vc first, then falls through to
-        // backend.backend match. For Jira, the _ arm returns None.
-        // But it calls build_version_control first for Github/Gitlab...
-        // Actually for Jira without vc, it hits the _ => Ok(None) arm directly.
-        // No credential resolution happens.
-        match result {
-            Ok(None) => {} // Expected: Jira without vc returns None
-            Ok(Some(_)) => panic!("expected None for Jira without vc"),
-            Err(e) => panic!("unexpected error: {e}"),
-        }
-    }
-
-    #[test]
-    fn resolve_vc_with_invalid_reference_errors() {
-        let backend = BackendConfig {
-            name: "jira-test".into(),
-            backend: Backend::Jira,
-            host: Some("https://test.atlassian.net".into()),
-            repo: Some("org/PROJ".into()),
-            default_board: None,
-            default_org: None,
-            path: None,
-            vc: Some("nonexistent".into()),
-            default_issue_type: None,
-            key: None,
-        };
-        let config = crate::config::Config {
-            backends: vec![backend.clone()],
-            ..crate::config::default_config()
-        };
-
-        let result = super::resolve_vc_for_backend(&backend, &config);
-        match result {
-            Err(e) => assert!(e.to_string().contains("does not exist"), "got: {e}"),
-            Ok(_) => panic!("expected error for nonexistent vc reference"),
-        }
-    }
-
-    #[test]
-    fn resolve_vc_rejects_jira_as_vc_target() {
-        let jira_backend = BackendConfig {
-            name: "jira-issues".into(),
-            backend: Backend::Jira,
-            host: Some("https://test.atlassian.net".into()),
-            repo: Some("org/PROJ".into()),
-            default_board: None,
-            default_org: None,
-            path: None,
-            vc: Some("jira-other".into()),
-            default_issue_type: None,
-            key: None,
-        };
-        let jira_other = BackendConfig {
-            name: "jira-other".into(),
-            backend: Backend::Jira,
-            host: Some("https://other.atlassian.net".into()),
-            repo: Some("org/OTHER".into()),
-            default_board: None,
-            default_org: None,
-            path: None,
-            vc: None,
-            default_issue_type: None,
-            key: None,
-        };
-        let config = crate::config::Config {
-            backends: vec![jira_backend.clone(), jira_other],
-            ..crate::config::default_config()
-        };
-
-        let result = super::resolve_vc_for_backend(&jira_backend, &config);
-        match result {
-            Err(e) => assert!(
-                e.to_string().contains("must be a github or gitlab backend"),
-                "got: {e}"
-            ),
-            Ok(_) => panic!("expected error for Jira as vc target"),
-        }
     }
 }

--- a/src/services/id_resolution.rs
+++ b/src/services/id_resolution.rs
@@ -28,7 +28,7 @@ pub fn resolve_id(
     let mut detected_candidate = None;
 
     if let Some(backend) = project_detection::detect_from_cwd(cwd, config)? {
-        let scope = issue_ids::effective_key(&backend);
+        let scope = issue_ids::effective_key(backend);
         let full_id = issue_ids::format_id(&scope, number);
         if crate::storage::issue_store::find_issue(paths, &full_id).is_ok() {
             return Ok(full_id);
@@ -197,7 +197,7 @@ mod tests {
     use super::{id_for_branch, resolve_id};
     use crate::config::{Config, default_config};
     use crate::error::RiptskError;
-    use crate::models::{Backend, BackendConfig};
+    use crate::models::{BackendKind, RepoProject, TasksBackendSpec, VCBackendSpec};
     use crate::paths::AppPaths;
     use camino::Utf8PathBuf;
     use tempfile::tempdir;
@@ -223,17 +223,26 @@ mod tests {
         let paths = app_paths(temp.path());
         touch_issue(&paths, "GH-GUB-DEV--61");
         touch_issue(&paths, "GL-FOO-BAR--61");
-        let config = config_with_backends(vec![BackendConfig {
+        let config = config_with_projects(vec![RepoProject {
             name: "dev-tools".into(),
-            backend: Backend::Github,
-            host: None,
-            repo: Some("GubCorp/dev-tools".into()),
+            vc_backend: VCBackendSpec {
+                kind: BackendKind::Github,
+                host: None,
+                repo: Some("GubCorp/dev-tools".into()),
+                path: Some(cwd.to_string()),
+            },
+            tasks_backend: TasksBackendSpec {
+                kind: BackendKind::Github,
+                host: None,
+                repo: Some("GubCorp/dev-tools".into()),
+                jira_project: None,
+                default_issue_type: None,
+                path: None,
+            },
             default_board: Some("personal".into()),
             default_org: None,
-            path: Some(cwd.to_string()),
-            vc: None,
-            default_issue_type: None,
             key: Some("GH-GUB-DEV".into()),
+            repo_project_label: None,
         }]);
 
         let resolved = resolve_id(&paths, &config, &cwd, "61").expect("resolve numeric id");
@@ -354,9 +363,9 @@ mod tests {
         std::fs::write(paths.issues_dir().join(format!("{id}.md")), contents).expect("write issue");
     }
 
-    fn config_with_backends(backends: Vec<BackendConfig>) -> Config {
+    fn config_with_projects(projects: Vec<RepoProject>) -> Config {
         let mut config = default_config();
-        config.backends = backends;
+        config.projects = projects;
         config
     }
 }

--- a/src/services/issue_ids.rs
+++ b/src/services/issue_ids.rs
@@ -1,5 +1,5 @@
 use crate::error::{ProjectKeyCollision, ProjectKeyProjectMeta, RiptskError};
-use crate::models::{Backend, BackendConfig};
+use crate::models::{BackendKind, RepoProject};
 use crate::paths::AppPaths;
 use crate::storage::{frontmatter, issue_store};
 use anyhow::Result;
@@ -8,16 +8,22 @@ use std::collections::{HashMap, HashSet};
 pub(crate) const MAX_KEY_LEN: usize = 16;
 pub(crate) const FALLBACK_KEY: &str = "TSK";
 
-pub fn derive_default_key(backend: &BackendConfig) -> String {
-    let source = match backend.backend {
-        Backend::Github | Backend::Gitlab | Backend::Jira => backend
-            .repo
-            .as_deref()
-            .and_then(|repo| repo.rsplit('/').next())
-            .filter(|value| !value.is_empty())
-            .unwrap_or(backend.name.as_str()),
-        Backend::Local => backend.name.as_str(),
-    };
+pub fn derive_default_key(repo_project: &RepoProject) -> String {
+    let source = repo_project
+        .tasks_backend
+        .jira_project
+        .as_deref()
+        .and_then(|jira_project| jira_project.rsplit('/').next())
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            repo_project
+                .vc_backend
+                .repo
+                .as_deref()
+                .and_then(|repo| repo.rsplit('/').next())
+                .filter(|value| !value.is_empty())
+        })
+        .unwrap_or(repo_project.name.as_str());
     sanitize_key_candidate(source)
 }
 
@@ -39,10 +45,10 @@ pub(crate) fn sanitize_key_candidate(raw: &str) -> String {
     buffer
 }
 
-pub fn effective_key(backend: &BackendConfig) -> String {
-    match backend.key.as_deref() {
+pub fn effective_key(repo_project: &RepoProject) -> String {
+    match repo_project.key.as_deref() {
         Some(key) if !key.is_empty() => key.to_owned(),
-        _ => derive_default_key(backend),
+        _ => derive_default_key(repo_project),
     }
 }
 
@@ -73,43 +79,31 @@ pub fn next_local_sequence(paths: &AppPaths, scope: &str) -> Result<u64> {
     Ok(max + 1)
 }
 
-/// Populate `backend.key` on every group member so that all backends pointing
-/// at the same logical project resolve to the same effective key at runtime.
-///
-/// Preference order within a group:
-/// 1. Any existing explicit key set on a member.
-/// 2. The derived default key of the first member.
-///
-/// Returns an error if two members of the same group declare conflicting
-/// explicit keys.
-pub fn normalize_backend_keys(backends: &mut [BackendConfig]) -> Result<(), RiptskError> {
-    // Build group -> canonical key using immutable borrows first.
+/// Populate `repo_project.key` on every group member so that all RepoProjects pointing
+/// at the same logical unit resolve to the same effective key at runtime.
+pub fn normalize_backend_keys(repo_projects: &mut [RepoProject]) -> Result<(), RiptskError> {
     let mut canonical: HashMap<String, String> = HashMap::new();
-    let mut errors: Option<(String, Vec<String>, String)> = None;
+    let mut errors: Option<(String, Vec<String>)> = None;
     {
-        let mut groups: HashMap<String, Vec<&BackendConfig>> = HashMap::new();
-        for backend in backends.iter() {
+        let mut groups: HashMap<String, Vec<&RepoProject>> = HashMap::new();
+        for repo_project in repo_projects.iter() {
             groups
-                .entry(logical_group_identity(backend))
+                .entry(logical_group_identity(repo_project))
                 .or_default()
-                .push(backend);
+                .push(repo_project);
         }
-        for (group_id, members) in &groups {
+        for members in groups.values() {
             let explicit: HashSet<String> = members
                 .iter()
-                .filter_map(|backend| backend.key.as_deref())
+                .filter_map(|repo_project| repo_project.key.as_deref())
                 .map(str::to_owned)
                 .collect();
             if explicit.len() > 1 {
                 let representative_name = members
                     .first()
-                    .map(|backend| backend.name.clone())
+                    .map(|repo_project| repo_project.name.clone())
                     .unwrap_or_default();
-                errors = Some((
-                    representative_name,
-                    explicit.into_iter().collect(),
-                    group_id.clone(),
-                ));
+                errors = Some((representative_name, explicit.into_iter().collect()));
                 break;
             }
             let key = explicit.into_iter().next().unwrap_or_else(|| {
@@ -119,50 +113,50 @@ pub fn normalize_backend_keys(backends: &mut [BackendConfig]) -> Result<(), Ript
                     .map(derive_default_key)
                     .unwrap_or_else(|| FALLBACK_KEY.to_owned())
             });
-            canonical.insert(group_id.clone(), key);
+            canonical.insert(logical_group_identity(members[0]), key);
         }
     }
-    if let Some((name, keys, _)) = errors {
+    if let Some((name, keys)) = errors {
         return Err(RiptskError::Config(format!(
-            "logical project '{}' declares multiple keys: {}",
+            "logical RepoProject '{}' declares multiple keys: {}",
             name,
             keys.join(", ")
         )));
     }
-    for backend in backends.iter_mut() {
-        let group_id = logical_group_identity(backend);
+    for repo_project in repo_projects.iter_mut() {
+        let group_id = logical_group_identity(repo_project);
         if let Some(key) = canonical.get(&group_id) {
-            backend.key = Some(key.clone());
+            repo_project.key = Some(key.clone());
         }
     }
     Ok(())
 }
 
 pub fn validate_no_key_collisions(
-    backends: &[BackendConfig],
+    repo_projects: &[RepoProject],
 ) -> std::result::Result<(), RiptskError> {
-    let mut groups: HashMap<String, Vec<&BackendConfig>> = HashMap::new();
-    for backend in backends {
+    let mut groups: HashMap<String, Vec<&RepoProject>> = HashMap::new();
+    for repo_project in repo_projects {
         groups
-            .entry(logical_group_identity(backend))
+            .entry(logical_group_identity(repo_project))
             .or_default()
-            .push(backend);
+            .push(repo_project);
     }
 
-    let mut seen: HashMap<String, &BackendConfig> = HashMap::new();
+    let mut seen: HashMap<String, &RepoProject> = HashMap::new();
     for members in groups.values() {
         let representative = members
             .first()
             .copied()
-            .ok_or_else(|| RiptskError::Config("empty backend group".into()))?;
+            .ok_or_else(|| RiptskError::Config("empty RepoProject group".into()))?;
         let explicit_keys = members
             .iter()
-            .filter_map(|backend| backend.key.as_deref())
+            .filter_map(|repo_project| repo_project.key.as_deref())
             .map(str::to_owned)
             .collect::<HashSet<_>>();
         if explicit_keys.len() > 1 {
             return Err(RiptskError::Config(format!(
-                "logical project '{}' declares multiple keys: {}",
+                "logical RepoProject '{}' declares multiple keys: {}",
                 representative.name,
                 explicit_keys.into_iter().collect::<Vec<_>>().join(", ")
             )));
@@ -182,8 +176,6 @@ pub fn validate_no_key_collisions(
     Ok(())
 }
 
-/// Validate that an explicit `backend.key` value matches the same syntax the
-/// interactive registration flow enforces.
 pub fn validate_explicit_key_syntax(key: &str) -> Result<(), String> {
     if key != key.trim() {
         return Err(format!(
@@ -213,49 +205,73 @@ pub fn validate_explicit_key_syntax(key: &str) -> Result<(), String> {
     Ok(())
 }
 
-pub(crate) fn logical_group_identity(backend: &BackendConfig) -> String {
-    match backend.backend {
-        Backend::Github => format!(
-            "github|{}|{}",
-            normalize_host(backend, "github.com"),
-            backend.repo.as_deref().unwrap_or_default()
-        ),
-        Backend::Gitlab => format!(
-            "gitlab|{}|{}",
-            normalize_host(backend, "gitlab.com"),
-            backend.repo.as_deref().unwrap_or_default()
-        ),
-        Backend::Jira if backend.repo.is_some() => format!(
+pub(crate) fn logical_group_identity(repo_project: &RepoProject) -> String {
+    if repo_project.tasks_backend.kind == BackendKind::Jira
+        && repo_project.tasks_backend.jira_project.is_some()
+    {
+        return format!(
             "jira|{}|{}",
-            normalize_host(backend, ""),
-            backend.repo.as_deref().unwrap_or_default()
+            normalize_host(repo_project.tasks_backend.host.as_deref(), ""),
+            repo_project
+                .tasks_backend
+                .jira_project
+                .as_deref()
+                .unwrap_or_default()
+        );
+    }
+
+    match repo_project.vc_backend.kind {
+        BackendKind::Github => format!(
+            "github|{}|{}",
+            normalize_host(repo_project.vc_backend.host.as_deref(), "github.com"),
+            repo_project.vc_backend.repo.as_deref().unwrap_or_default()
+        ),
+        BackendKind::Gitlab => format!(
+            "gitlab|{}|{}",
+            normalize_host(repo_project.vc_backend.host.as_deref(), "gitlab.com"),
+            repo_project.vc_backend.repo.as_deref().unwrap_or_default()
         ),
         _ => format!(
             "local|{}",
-            backend.path.as_deref().unwrap_or(backend.name.as_str())
+            repo_project
+                .vc_backend
+                .path
+                .as_deref()
+                .or(repo_project.tasks_backend.path.as_deref())
+                .unwrap_or(repo_project.name.as_str())
         ),
     }
 }
 
-fn normalize_host(backend: &BackendConfig, default_host: &str) -> String {
-    backend
-        .host
-        .as_deref()
-        .unwrap_or(default_host)
+fn normalize_host(host: Option<&str>, default_host: &str) -> String {
+    host.unwrap_or(default_host)
         .trim_start_matches("https://")
         .trim_start_matches("http://")
         .trim_end_matches('/')
         .to_owned()
 }
 
-fn project_meta(backend: &BackendConfig) -> ProjectKeyProjectMeta {
+fn project_meta(repo_project: &RepoProject) -> ProjectKeyProjectMeta {
     ProjectKeyProjectMeta {
-        name: backend.name.clone(),
-        backend: backend.backend.as_str().to_owned(),
-        host: backend.host.clone(),
-        repo: backend.repo.clone(),
-        path: backend.path.clone(),
-        existing_key: backend.key.clone(),
+        name: repo_project.name.clone(),
+        backend: repo_project.tasks_backend.kind.as_str().to_owned(),
+        host: repo_project
+            .tasks_backend
+            .host
+            .clone()
+            .or_else(|| repo_project.vc_backend.host.clone()),
+        repo: repo_project
+            .tasks_backend
+            .repo
+            .clone()
+            .or_else(|| repo_project.tasks_backend.jira_project.clone())
+            .or_else(|| repo_project.vc_backend.repo.clone()),
+        path: repo_project
+            .vc_backend
+            .path
+            .clone()
+            .or_else(|| repo_project.tasks_backend.path.clone()),
+        existing_key: repo_project.key.clone(),
     }
 }
 
@@ -266,206 +282,209 @@ mod tests {
         validate_explicit_key_syntax, validate_no_key_collisions,
     };
     use crate::error::RiptskError;
-    use crate::models::{Backend, BackendConfig};
+    use crate::models::{BackendKind, RepoProject, TasksBackendSpec, VCBackendSpec};
 
-    fn backend(kind: Backend, name: &str, repo: Option<&str>, key: Option<&str>) -> BackendConfig {
-        BackendConfig {
+    fn repo_project(
+        vc_kind: BackendKind,
+        tasks_kind: BackendKind,
+        name: &str,
+        vc_repo: Option<&str>,
+        jira_project: Option<&str>,
+        key: Option<&str>,
+    ) -> RepoProject {
+        RepoProject {
             name: name.into(),
-            backend: kind,
-            host: None,
-            repo: repo.map(str::to_owned),
+            vc_backend: VCBackendSpec {
+                kind: vc_kind,
+                host: None,
+                repo: vc_repo.map(str::to_owned),
+                path: None,
+            },
+            tasks_backend: TasksBackendSpec {
+                kind: tasks_kind,
+                host: None,
+                repo: vc_repo.map(str::to_owned),
+                jira_project: jira_project.map(str::to_owned),
+                default_issue_type: None,
+                path: None,
+            },
             default_board: None,
             default_org: None,
-            path: None,
-            vc: None,
-            default_issue_type: None,
             key: key.map(str::to_owned),
+            repo_project_label: None,
         }
     }
 
     #[test]
     fn derive_default_key_uses_github_repo_tail() {
-        let backend = backend(Backend::Github, "fallback", Some("owner/my-repo"), None);
-        assert_eq!(derive_default_key(&backend), "MYREPO");
-    }
-
-    #[test]
-    fn derive_default_key_uses_gitlab_repo_tail() {
-        let backend = backend(
-            Backend::Gitlab,
+        let repo_project = repo_project(
+            BackendKind::Github,
+            BackendKind::Github,
             "fallback",
-            Some("group/sub/project-x"),
+            Some("owner/my-repo"),
+            None,
             None,
         );
-        assert_eq!(derive_default_key(&backend), "PROJECTX");
+        assert_eq!(derive_default_key(&repo_project), "MYREPO");
     }
 
     #[test]
-    fn derive_default_key_uses_jira_repo_tail() {
-        let backend = backend(Backend::Jira, "fallback", Some("org/PROJ"), None);
-        assert_eq!(derive_default_key(&backend), "PROJ");
+    fn derive_default_key_uses_jira_project_tail() {
+        let repo_project = repo_project(
+            BackendKind::Local,
+            BackendKind::Jira,
+            "fallback",
+            None,
+            Some("org/PROJ"),
+            None,
+        );
+        assert_eq!(derive_default_key(&repo_project), "PROJ");
     }
 
     #[test]
     fn derive_default_key_uses_local_name() {
-        let backend = backend(Backend::Local, "ice shelf tracker", None, None);
-        assert_eq!(derive_default_key(&backend), "ICESHELFTRACKER");
+        let repo_project = repo_project(
+            BackendKind::Local,
+            BackendKind::Local,
+            "ice shelf tracker",
+            None,
+            None,
+            None,
+        );
+        assert_eq!(derive_default_key(&repo_project), "ICESHELFTRACKER");
     }
 
     #[test]
     fn derive_default_key_strips_non_ascii_and_punctuation() {
-        let backend = backend(Backend::Local, "🦀 crab-ops", None, None);
-        assert_eq!(derive_default_key(&backend), "CRABOPS");
+        let repo_project = repo_project(
+            BackendKind::Local,
+            BackendKind::Local,
+            "🦀 crab-ops",
+            None,
+            None,
+            None,
+        );
+        assert_eq!(derive_default_key(&repo_project), "CRABOPS");
     }
 
     #[test]
     fn derive_default_key_falls_back_to_tsk() {
-        let backend = backend(Backend::Local, "——", None, None);
-        assert_eq!(derive_default_key(&backend), "TSK");
+        let repo_project = repo_project(
+            BackendKind::Local,
+            BackendKind::Local,
+            "——",
+            None,
+            None,
+            None,
+        );
+        assert_eq!(derive_default_key(&repo_project), "TSK");
     }
 
     #[test]
     fn derive_default_key_truncates_to_max_key_len() {
-        let backend = backend(
-            Backend::Github,
+        let repo_project = repo_project(
+            BackendKind::Github,
+            BackendKind::Github,
             "fallback",
             Some("owner/averylongrepositoryname"),
             None,
+            None,
         );
-        let derived = derive_default_key(&backend);
+        let derived = derive_default_key(&repo_project);
         assert_eq!(derived.len(), MAX_KEY_LEN);
         assert_eq!(derived, "AVERYLONGREPOSIT");
     }
 
     #[test]
     fn effective_key_prefers_explicit_override() {
-        let backend = backend(
-            Backend::Github,
+        let repo_project = repo_project(
+            BackendKind::Github,
+            BackendKind::Github,
             "fallback",
             Some("owner/repo"),
+            None,
             Some("OVERRIDE"),
         );
-        assert_eq!(effective_key(&backend), "OVERRIDE");
+        assert_eq!(effective_key(&repo_project), "OVERRIDE");
     }
 
     #[test]
     fn effective_key_empty_override_falls_back_to_derived() {
-        let backend = backend(Backend::Github, "fallback", Some("owner/repo"), Some(""));
-        assert_eq!(effective_key(&backend), "REPO");
+        let repo_project = repo_project(
+            BackendKind::Github,
+            BackendKind::Github,
+            "fallback",
+            Some("owner/repo"),
+            None,
+            Some(""),
+        );
+        assert_eq!(effective_key(&repo_project), "REPO");
     }
 
     #[test]
     fn validate_no_key_collisions_allows_same_remote_dupes() {
-        let first = backend(Backend::Github, "repo-a", Some("owner/repo"), None);
-        let mut second = backend(Backend::Github, "repo-b", Some("owner/repo"), None);
-        second.path = Some("/tmp/worktree".into());
-        assert!(validate_no_key_collisions(&[first, second]).is_ok());
-    }
-
-    #[test]
-    fn validate_no_key_collisions_allows_same_remote_explicit_match() {
-        let first = backend(Backend::Github, "repo-a", Some("owner/repo"), Some("SAME"));
-        let second = backend(Backend::Github, "repo-b", Some("owner/repo"), Some("SAME"));
-        assert!(validate_no_key_collisions(&[first, second]).is_ok());
-    }
-
-    #[test]
-    fn validate_no_key_collisions_rejects_same_remote_explicit_mismatch() {
-        let first = backend(Backend::Github, "repo-a", Some("owner/repo"), Some("ONE"));
-        let second = backend(Backend::Github, "repo-b", Some("owner/repo"), Some("TWO"));
-        let error = validate_no_key_collisions(&[first, second]).expect_err("mismatch");
-        assert!(matches!(error, RiptskError::Config(_)));
-    }
-
-    #[test]
-    fn validate_no_key_collisions_allows_distinct_defaults() {
-        let first = backend(Backend::Github, "alpha", Some("owner/alpha"), None);
-        let second = backend(Backend::Github, "beta", Some("owner/beta"), None);
+        let first = repo_project(
+            BackendKind::Github,
+            BackendKind::Github,
+            "repo-a",
+            Some("owner/repo"),
+            None,
+            None,
+        );
+        let second = repo_project(
+            BackendKind::Github,
+            BackendKind::Github,
+            "repo-b",
+            Some("owner/repo"),
+            None,
+            None,
+        );
         assert!(validate_no_key_collisions(&[first, second]).is_ok());
     }
 
     #[test]
     fn validate_no_key_collisions_rejects_distinct_project_collisions() {
-        let first = backend(Backend::Github, "alpha-one", Some("owner/alpha"), None);
-        let second = backend(Backend::Github, "alpha-two", Some("owner2/alpha"), None);
-        let error = validate_no_key_collisions(&[first, second]).expect_err("collision");
-        match error {
-            RiptskError::KeyCollision(collision) => {
-                assert_eq!(collision.attempted_key, "ALPHA");
-                let names = [
-                    collision.conflicting_project.name,
-                    collision.new_project.name,
-                ];
-                assert!(names.contains(&"alpha-one".into()));
-                assert!(names.contains(&"alpha-two".into()));
-            }
-            other => panic!("expected key collision, got {other}"),
-        }
-    }
-
-    #[test]
-    fn validate_no_key_collisions_rejects_distinct_local_collisions() {
-        let mut first = backend(Backend::Local, "proj-a", None, None);
-        first.path = Some("/a".into());
-        let mut second = backend(Backend::Local, "proj-a", None, None);
-        second.path = Some("/b".into());
+        let first = repo_project(
+            BackendKind::Github,
+            BackendKind::Github,
+            "alpha-one",
+            Some("owner/alpha"),
+            None,
+            None,
+        );
+        let second = repo_project(
+            BackendKind::Github,
+            BackendKind::Github,
+            "alpha-two",
+            Some("other/alpha"),
+            None,
+            None,
+        );
         let error = validate_no_key_collisions(&[first, second]).expect_err("collision");
         assert!(matches!(error, RiptskError::KeyCollision(_)));
     }
 
     #[test]
-    fn validate_no_key_collisions_allows_same_local_path() {
-        let mut first = backend(Backend::Local, "a", None, None);
-        first.path = Some("/x".into());
-        let mut second = backend(Backend::Local, "b", None, None);
-        second.path = Some("/x".into());
-        assert!(validate_no_key_collisions(&[first, second]).is_ok());
-    }
-
-    #[test]
-    fn normalize_backend_keys_aligns_same_local_path_siblings() {
-        let mut first = backend(Backend::Local, "a", None, None);
-        first.path = Some("/x".into());
-        let mut second = backend(Backend::Local, "b", None, None);
-        second.path = Some("/x".into());
-        let mut backends = vec![first, second];
-        normalize_backend_keys(&mut backends).expect("normalize");
-        assert_eq!(backends[0].key, backends[1].key);
-        // The canonical key comes from the first member's derived default.
-        assert_eq!(backends[0].key.as_deref(), Some("A"));
-    }
-
-    #[test]
-    fn normalize_backend_keys_inherits_existing_explicit_key() {
-        let mut first = backend(Backend::Local, "a", None, Some("ALPHA"));
-        first.path = Some("/x".into());
-        let mut second = backend(Backend::Local, "b", None, None);
-        second.path = Some("/x".into());
-        let mut backends = vec![first, second];
-        normalize_backend_keys(&mut backends).expect("normalize");
-        assert_eq!(backends[0].key.as_deref(), Some("ALPHA"));
-        assert_eq!(backends[1].key.as_deref(), Some("ALPHA"));
-    }
-
-    #[test]
-    fn normalize_backend_keys_rejects_conflicting_explicit_keys_in_same_group() {
-        let mut first = backend(Backend::Local, "a", None, Some("ONE"));
-        first.path = Some("/x".into());
-        let mut second = backend(Backend::Local, "b", None, Some("TWO"));
-        second.path = Some("/x".into());
-        let mut backends = vec![first, second];
-        let error = normalize_backend_keys(&mut backends).expect_err("conflict");
-        assert!(matches!(error, RiptskError::Config(_)));
-    }
-
-    #[test]
-    fn normalize_backend_keys_leaves_distinct_groups_alone() {
-        let first = backend(Backend::Github, "alpha", Some("owner/alpha"), None);
-        let second = backend(Backend::Github, "beta", Some("owner/beta"), None);
-        let mut backends = vec![first, second];
-        normalize_backend_keys(&mut backends).expect("normalize");
-        assert_eq!(backends[0].key.as_deref(), Some("ALPHA"));
-        assert_eq!(backends[1].key.as_deref(), Some("BETA"));
+    fn normalize_backend_keys_aligns_same_jira_project_siblings() {
+        let first = repo_project(
+            BackendKind::Local,
+            BackendKind::Jira,
+            "a",
+            None,
+            Some("org/PROJ"),
+            None,
+        );
+        let second = repo_project(
+            BackendKind::Local,
+            BackendKind::Jira,
+            "b",
+            None,
+            Some("org/PROJ"),
+            None,
+        );
+        let mut repo_projects = vec![first, second];
+        normalize_backend_keys(&mut repo_projects).expect("normalize");
+        assert_eq!(repo_projects[0].key, repo_projects[1].key);
     }
 
     #[test]
@@ -483,10 +502,8 @@ mod tests {
         assert!(validate_explicit_key_syntax("A--B").is_err());
         assert!(validate_explicit_key_syntax("-ALPHA").is_err());
         assert!(validate_explicit_key_syntax("ALPHA-").is_err());
-        assert!(validate_explicit_key_syntax("ALPHABETAGAMMADELTA").is_err()); // > MAX_KEY_LEN
+        assert!(validate_explicit_key_syntax("ALPHABETAGAMMADELTA").is_err());
         assert!(validate_explicit_key_syntax("A B").is_err());
-        // Surrounding whitespace must be rejected so config-loaded keys and
-        // interactively-entered keys follow the same rules.
         assert!(validate_explicit_key_syntax(" FOO").is_err());
         assert!(validate_explicit_key_syntax("FOO ").is_err());
         assert!(validate_explicit_key_syntax("\tFOO").is_err());

--- a/src/services/issue_service.rs
+++ b/src/services/issue_service.rs
@@ -2,7 +2,7 @@ use crate::cli::{LsArgs, NewArgs};
 use crate::config::{Config, parse_priority, parse_state};
 use crate::domain::issue::{IssueDocument, IssueFrontmatter, IssueState, Priority};
 use crate::error::RiptskError;
-use crate::models::Backend;
+use crate::models::BackendKind;
 use crate::paths::AppPaths;
 use crate::services::issue_ids;
 use crate::services::templates::TemplateService;
@@ -35,8 +35,8 @@ pub struct IssueDraft {
     pub org: Option<String>,
     pub body: String,
     pub order: u32,
-    pub backend: Option<Backend>,
-    pub repo: Option<String>,
+    pub tasks_backend_kind: Option<BackendKind>,
+    pub tasks_repo: Option<String>,
 }
 
 pub struct ListMatchingResult {
@@ -64,7 +64,7 @@ impl<'a> IssueService<'a> {
                     .to_string(),
             );
             crate::services::project_detection::detect_from_cwd(&cwd, self.config)?
-                .map(|r| r.name)
+                .map(|r| r.name.clone())
                 .unwrap_or_else(|| "personal".into())
         };
         let template_name = args
@@ -108,8 +108,8 @@ impl<'a> IssueService<'a> {
             order: self
                 .next_order_for_lane(&board, status.as_str())
                 .map_err(RiptskError::Other)?,
-            backend: self.project_backend(&project),
-            repo: self.project_repo(&project),
+            tasks_backend_kind: self.project_tasks_backend_kind(&project),
+            tasks_repo: self.project_tasks_repo(&project),
         })
     }
 
@@ -367,43 +367,49 @@ impl<'a> IssueService<'a> {
         }
     }
 
-    fn project_backend(&self, project: &str) -> Option<Backend> {
+    fn project_tasks_backend_kind(&self, project: &str) -> Option<BackendKind> {
         self.config
-            .backends
+            .projects
             .iter()
-            .find(|backend| backend.name == project)
-            .map(|backend| backend.backend.clone())
+            .find(|repo_project| repo_project.name == project)
+            .map(|repo_project| repo_project.tasks_backend.kind.clone())
     }
 
-    fn project_repo(&self, project: &str) -> Option<String> {
+    fn project_tasks_repo(&self, project: &str) -> Option<String> {
         self.config
-            .backends
+            .projects
             .iter()
-            .find(|backend| backend.name == project)
-            .and_then(|backend| backend.repo.clone())
+            .find(|repo_project| repo_project.name == project)
+            .and_then(|repo_project| {
+                repo_project
+                    .tasks_backend
+                    .repo
+                    .clone()
+                    .or_else(|| repo_project.tasks_backend.jira_project.clone())
+            })
     }
 
     fn project_default_board(&self, project: &str) -> Option<String> {
         self.config
-            .backends
+            .projects
             .iter()
-            .find(|backend| backend.name == project)
-            .and_then(|backend| backend.default_board.clone())
+            .find(|repo_project| repo_project.name == project)
+            .and_then(|repo_project| repo_project.default_board.clone())
     }
 
     fn project_default_org(&self, project: &str) -> Option<String> {
         self.config
-            .backends
+            .projects
             .iter()
-            .find(|backend| backend.name == project)
-            .and_then(|backend| backend.default_org.clone())
+            .find(|repo_project| repo_project.name == project)
+            .and_then(|repo_project| repo_project.default_org.clone())
     }
 
     fn project_effective_key(&self, project: &str) -> String {
         self.config
-            .backends
+            .projects
             .iter()
-            .find(|backend| backend.name == project)
+            .find(|repo_project| repo_project.name == project)
             .map(issue_ids::effective_key)
             .unwrap_or_else(|| issue_ids::sanitize_key_candidate(project))
     }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -6,6 +6,7 @@ pub mod issue_ids;
 pub mod issue_service;
 pub mod project_detection;
 pub mod recurrence;
+pub mod repo_project_label;
 pub mod sync_engine;
 pub mod templates;
 pub mod view_builder;

--- a/src/services/project_detection.rs
+++ b/src/services/project_detection.rs
@@ -2,11 +2,11 @@ use crate::adapters::ai::AiBackend;
 use crate::adapters::git::GitBackend;
 use crate::adapters::prompts::PromptBackend;
 use crate::config::{Config, load_config, save_config};
-use crate::error::RiptskError;
-use crate::models::{Backend, BackendConfig};
+use crate::error::{ProjectKeyCollision, ProjectKeyProjectMeta, RiptskError};
+use crate::models::{BackendKind, RepoProject, TasksBackendSpec, VCBackendSpec};
 use crate::paths::AppPaths;
 use crate::services::auto_commit::maybe_auto_commit;
-use crate::services::issue_ids;
+use crate::services::{issue_ids, repo_project_label};
 use anyhow::Context;
 use camino::Utf8Path;
 use std::io::IsTerminal;
@@ -28,8 +28,6 @@ pub fn ensure_registered(
             .to_string_lossy()
             .to_string(),
     );
-    // Best-effort: if git is unavailable or detection fails, skip silently
-    // and let commands handle errors with their own messages.
     let detected = match detect_from_cwd(&cwd, &config) {
         Ok(result) => result,
         Err(_) => return Ok(()),
@@ -42,9 +40,6 @@ pub fn ensure_registered(
     } else {
         None
     };
-    // Best-effort: if auto-registration fails (e.g. a derived-key collision in
-    // a non-interactive environment), skip silently so unrelated commands still
-    // run. Commands that require a registered project raise their own errors.
     let registered = match register_project_auto(
         &cwd,
         &mut config,
@@ -67,11 +62,10 @@ pub fn ensure_registered(
     Ok(())
 }
 
-pub fn detect_from_cwd(
+pub fn detect_from_cwd<'a>(
     cwd: &Utf8Path,
-    config: &Config,
-) -> Result<Option<BackendConfig>, RiptskError> {
-    // Git remote URL matching first — skip if git root is $HOME.
+    config: &'a Config,
+) -> Result<Option<&'a RepoProject>, RiptskError> {
     let output = Command::new("git")
         .arg("-C")
         .arg(cwd)
@@ -85,34 +79,29 @@ pub fn detect_from_cwd(
     if output.status.success() && !git_root_is_home(cwd)? {
         let url = String::from_utf8_lossy(&output.stdout);
         let normalized = normalize_url(url.trim());
-        if let Some(backend) = config
-            .backends
+        if let Some(repo_project) = config
+            .projects
             .iter()
-            .find(|backend| normalized == normalized_backend(backend))
+            .find(|repo_project| normalized == normalized_vc_backend(&repo_project.vc_backend))
         {
-            return Ok(Some(backend.clone()));
+            return Ok(Some(repo_project));
         }
     }
 
-    // Path-based matching — works for all project types including non-git.
-    if let Some(backend) = config
-        .backends
-        .iter()
-        .find(|backend| {
-            backend
+    Ok(config.projects.iter().find(|repo_project| {
+        repo_project
+            .vc_backend
+            .path
+            .as_ref()
+            .is_some_and(|path| path_is_under(cwd.as_str(), path))
+            || repo_project
+                .tasks_backend
                 .path
                 .as_ref()
-                .is_some_and(|p| path_is_under(cwd.as_str(), p))
-        })
-        .cloned()
-    {
-        return Ok(Some(backend));
-    }
-
-    Ok(None)
+                .is_some_and(|path| path_is_under(cwd.as_str(), path))
+    }))
 }
 
-/// Check if `cwd` is the same directory or a subdirectory of `base`, using canonical paths when possible.
 fn path_is_under(cwd: &str, base: &str) -> bool {
     let cwd_canon = std::fs::canonicalize(cwd)
         .map(|p| p.to_string_lossy().to_string())
@@ -146,16 +135,16 @@ pub fn normalize_url(url: &str) -> String {
     }
 }
 
-pub fn infer_type(host: &str) -> Backend {
+pub fn infer_type(host: &str) -> BackendKind {
     match host {
-        "github.com" => Backend::Github,
-        value if value.contains("gitlab") => Backend::Gitlab,
-        _ => Backend::Local,
+        "github.com" => BackendKind::Github,
+        value if value.contains("gitlab") => BackendKind::Gitlab,
+        _ => BackendKind::Local,
     }
 }
 
-pub fn normalized_backend(backend: &BackendConfig) -> String {
-    match (&backend.host, &backend.repo) {
+pub fn normalized_vc_backend(vc_backend: &VCBackendSpec) -> String {
+    match (&vc_backend.host, &vc_backend.repo) {
         (Some(host), Some(repo)) => {
             let host = host
                 .strip_prefix("https://")
@@ -163,10 +152,10 @@ pub fn normalized_backend(backend: &BackendConfig) -> String {
                 .unwrap_or(host);
             format!("{}:{}", host.trim_end_matches('/'), repo)
         }
-        (None, Some(repo)) if backend.backend == Backend::Github => {
+        (None, Some(repo)) if vc_backend.kind == BackendKind::Github => {
             format!("github.com:{repo}")
         }
-        (None, Some(repo)) if backend.backend == Backend::Gitlab => {
+        (None, Some(repo)) if vc_backend.kind == BackendKind::Gitlab => {
             format!("gitlab.com:{repo}")
         }
         _ => String::new(),
@@ -178,44 +167,59 @@ pub fn register_project_auto(
     config: &mut Config,
     prompts: Option<&dyn PromptBackend>,
     ai: Option<&dyn AiBackend>,
-) -> Result<Option<BackendConfig>, RiptskError> {
-    // Never auto-register $HOME itself as a project.
+) -> Result<Option<RepoProject>, RiptskError> {
     if is_home_dir(cwd) {
         return Ok(None);
     }
 
     if let Some(existing) = detect_from_cwd(cwd, config)? {
-        return Ok(Some(existing));
+        return Ok(Some(existing.clone()));
     }
 
-    // Remote git repo — register by URL (skip if git root is $HOME).
     if !git_root_is_home(cwd)? {
         if let Some(url) = git_origin_url(cwd)? {
             let normalized = normalize_url(url.trim());
             let (host, repo) = split_host_repo(&normalized)
                 .ok_or_else(|| RiptskError::General("failed to normalize git remote URL".into()))?;
-            let Some(name) = deduplicate_name(repo.rsplit('/').next().unwrap_or(repo), cwd, config)
-            else {
+            let repo_tail = repo.rsplit('/').next().unwrap_or(repo);
+            let Some(name) = deduplicate_name(repo_tail, cwd, config) else {
                 return Ok(None);
             };
-            let mut backend = BackendConfig {
+            let host_url = format!("https://{}", host.trim_end_matches('/'));
+            let mut repo_project = RepoProject {
                 name,
-                backend: infer_type(host),
-                host: Some(format!("https://{}", host.trim_end_matches('/'))),
-                repo: Some(repo.to_owned()),
+                vc_backend: VCBackendSpec {
+                    kind: infer_type(host),
+                    host: Some(host_url.clone()),
+                    repo: Some(repo.to_owned()),
+                    path: None,
+                },
+                tasks_backend: TasksBackendSpec {
+                    kind: infer_type(host),
+                    host: Some(host_url),
+                    repo: Some(repo.to_owned()),
+                    jira_project: None,
+                    default_issue_type: None,
+                    path: None,
+                },
                 default_board: Some("personal".into()),
                 default_org: None,
-                path: None,
-                vc: None,
-                default_issue_type: None,
                 key: None,
+                // Only Jira TasksBackends use `repo_project_label`; auto-
+                // registration in this branch always targets GitHub/GitLab via
+                // `infer_type(host)`, so leave it unset. This also avoids the
+                // edge case where `derive_default` can sanitize down to `""`
+                // (e.g. for emoji-only or all-punctuation directory names),
+                // which would otherwise fail validation for a project that
+                // does not use the label at all.
+                repo_project_label: None,
             };
-            finalize_backend_registration(config, &mut backend, prompts, ai)?;
-            config.backends.push(backend.clone());
-            return Ok(Some(backend));
+            validate_new_repo_project(config, &repo_project)?;
+            finalize_repo_project_registration(config, &mut repo_project, prompts, ai)?;
+            config.projects.push(repo_project.clone());
+            return Ok(Some(repo_project));
         }
 
-        // Local git repo (no remote) — register by path.
         if is_inside_work_tree(cwd)? {
             let Some(name) = deduplicate_name(cwd.file_name().unwrap_or("project"), cwd, config)
             else {
@@ -224,67 +228,91 @@ pub fn register_project_auto(
             let path = std::fs::canonicalize(cwd.as_std_path())
                 .map(|value| value.to_string_lossy().to_string())
                 .unwrap_or_else(|_| cwd.as_str().to_owned());
-            let mut backend = BackendConfig {
+            let mut repo_project = RepoProject {
                 name,
-                backend: Backend::Local,
-                host: None,
-                repo: None,
+                vc_backend: VCBackendSpec {
+                    kind: BackendKind::Local,
+                    host: None,
+                    repo: None,
+                    path: Some(path.clone()),
+                },
+                tasks_backend: TasksBackendSpec {
+                    kind: BackendKind::Local,
+                    host: None,
+                    repo: None,
+                    jira_project: None,
+                    default_issue_type: None,
+                    path: Some(path),
+                },
                 default_board: Some("personal".into()),
                 default_org: None,
-                path: Some(path),
-                vc: None,
-                default_issue_type: None,
                 key: None,
+                // Local/Local RepoProjects do not use `repo_project_label`.
+                repo_project_label: None,
             };
-            finalize_backend_registration(config, &mut backend, prompts, ai)?;
-            config.backends.push(backend.clone());
-            return Ok(Some(backend));
+            validate_new_repo_project(config, &repo_project)?;
+            finalize_repo_project_registration(config, &mut repo_project, prompts, ai)?;
+            config.projects.push(repo_project.clone());
+            return Ok(Some(repo_project));
         }
     }
 
-    // Non-git directory — register as Backend::Local using cwd.
     let Some(name) = deduplicate_name(cwd.file_name().unwrap_or("project"), cwd, config) else {
         return Ok(None);
     };
     let path = std::fs::canonicalize(cwd.as_std_path())
         .map(|value| value.to_string_lossy().to_string())
         .unwrap_or_else(|_| cwd.as_str().to_owned());
-    let mut backend = BackendConfig {
+    let mut repo_project = RepoProject {
         name,
-        backend: Backend::Local,
-        host: None,
-        repo: None,
+        vc_backend: VCBackendSpec {
+            kind: BackendKind::Local,
+            host: None,
+            repo: None,
+            path: Some(path.clone()),
+        },
+        tasks_backend: TasksBackendSpec {
+            kind: BackendKind::Local,
+            host: None,
+            repo: None,
+            jira_project: None,
+            default_issue_type: None,
+            path: Some(path),
+        },
         default_board: Some("personal".into()),
         default_org: None,
-        path: Some(path),
-        vc: None,
-        default_issue_type: None,
         key: None,
+        // Non-git, Local/Local RepoProject — `repo_project_label` is a Jira
+        // partitioning concept and has no effect here, so leave it unset.
+        repo_project_label: None,
     };
-    finalize_backend_registration(config, &mut backend, prompts, ai)?;
-    config.backends.push(backend.clone());
-    Ok(Some(backend))
+    validate_new_repo_project(config, &repo_project)?;
+    finalize_repo_project_registration(config, &mut repo_project, prompts, ai)?;
+    config.projects.push(repo_project.clone());
+    Ok(Some(repo_project))
 }
 
-/// Ensure the backend name is unique within the config. If `base` already exists,
-/// prepend the parent directory name. Returns `None` if uniqueness cannot be achieved.
 fn deduplicate_name(base: &str, cwd: &Utf8Path, config: &Config) -> Option<String> {
-    if !config.backends.iter().any(|b| b.name == base) {
+    if !config
+        .projects
+        .iter()
+        .any(|repo_project| repo_project.name == base)
+    {
         return Some(base.to_owned());
     }
     let parent = cwd.parent().and_then(|p| p.file_name()).unwrap_or("dup");
     let candidate = format!("{parent}-{base}");
-    if !config.backends.iter().any(|b| b.name == candidate) {
+    if !config
+        .projects
+        .iter()
+        .any(|repo_project| repo_project.name == candidate)
+    {
         return Some(candidate);
     }
     None
 }
 
-/// Split a normalized "host:repo" or "host:port:repo" string into (host, repo).
-/// The repo part is identified as the segment after the last ':' that contains '/'.
 fn split_host_repo(normalized: &str) -> Option<(&str, &str)> {
-    // Try splitting from the right: if the part after the last ':' contains '/',
-    // it's the repo path. Otherwise fall back to split_once for "host:repo".
     if let Some(pos) = normalized.rfind(':') {
         let candidate = &normalized[pos + 1..];
         if candidate.contains('/') {
@@ -317,13 +345,14 @@ pub fn register_project_interactive(
     prompts: &dyn PromptBackend,
     ai: Option<&dyn AiBackend>,
     cwd: &Utf8Path,
-) -> Result<BackendConfig, RiptskError> {
+    repo_project_label_override: Option<String>,
+) -> Result<RepoProject, RiptskError> {
     if let Some(existing) = detect_from_cwd(cwd, config)? {
-        return Ok(existing);
+        return Ok(existing.clone());
     }
 
     let repo_url = git_origin_url(cwd)?;
-    let (default_name, default_type, default_host, default_repo, default_path) =
+    let (default_name, default_vc_kind, default_host, default_repo, default_path, origin_tail) =
         if let Some(url) = repo_url {
             let normalized = normalize_url(&url);
             let (host, repo) = split_host_repo(&normalized)
@@ -334,11 +363,12 @@ pub fn register_project_interactive(
                 Some(host.to_owned()),
                 Some(repo.to_owned()),
                 None,
+                Some(repo.rsplit('/').next().unwrap_or(repo).to_owned()),
             )
         } else {
             (
                 cwd.file_name().unwrap_or("project").to_owned(),
-                Backend::Local,
+                BackendKind::Local,
                 None,
                 None,
                 Some(
@@ -346,76 +376,190 @@ pub fn register_project_interactive(
                         .map(|path| path.to_string_lossy().to_string())
                         .unwrap_or_else(|_| cwd.as_str().to_owned()),
                 ),
+                None,
             )
         };
 
-    let name = prompts.input("Backend name", Some(&default_name))?;
-    let backend = match prompts
-        .select(
-            "Backend type",
-            &["github".into(), "gitlab".into(), "local".into()],
-            match default_type {
-                Backend::Github => 0,
-                Backend::Gitlab => 1,
-                Backend::Jira => 0,
-                Backend::Local => 2,
-            },
-        )?
-        .as_str()
-    {
-        "github" => Backend::Github,
-        "gitlab" => Backend::Gitlab,
-        _ => Backend::Local,
-    };
-    let host = if backend == Backend::Local {
+    let name = prompts.input("RepoProject name", Some(&default_name))?;
+    let vc_kind = select_backend_kind(
+        prompts,
+        "VCBackend type",
+        &["github", "gitlab", "local"],
+        default_vc_kind.clone(),
+    )?;
+    let vc_host = if vc_kind == BackendKind::Local {
         None
     } else {
-        let default_host = default_host.as_deref().unwrap_or(match backend {
-            Backend::Github => "github.com",
-            Backend::Gitlab => "gitlab.com",
-            Backend::Jira => "",
-            Backend::Local => "",
+        let default_host = default_host.as_deref().unwrap_or(match vc_kind {
+            BackendKind::Github => "github.com",
+            BackendKind::Gitlab => "gitlab.com",
+            BackendKind::Jira | BackendKind::Local => "",
         });
-        let host = prompts.input("Host", Some(default_host))?;
+        let host = prompts.input("VCBackend host", Some(default_host))?;
         Some(format!(
             "https://{}",
             host.trim_start_matches("https://")
                 .trim_start_matches("http://")
         ))
     };
-    let repo = if backend == Backend::Local {
+    let vc_repo = if vc_kind == BackendKind::Local {
         None
     } else {
-        Some(prompts.input("Repo", default_repo.as_deref())?)
+        Some(prompts.input("VCBackend repo", default_repo.as_deref())?)
     };
+
+    let default_tasks_kind = if vc_kind == BackendKind::Local {
+        BackendKind::Local
+    } else {
+        vc_kind.clone()
+    };
+    let tasks_kind = select_backend_kind(
+        prompts,
+        "TasksBackend type",
+        &["github", "gitlab", "jira", "local"],
+        default_tasks_kind,
+    )?;
+    let tasks_host = if tasks_kind == BackendKind::Local {
+        None
+    } else {
+        let default_tasks_host = default_host.as_deref().unwrap_or(match tasks_kind {
+            BackendKind::Github => "github.com",
+            BackendKind::Gitlab => "gitlab.com",
+            BackendKind::Jira => "",
+            BackendKind::Local => "",
+        });
+        let host = prompts.input("TasksBackend host", Some(default_tasks_host))?;
+        Some(format!(
+            "https://{}",
+            host.trim_start_matches("https://")
+                .trim_start_matches("http://")
+        ))
+    };
+    let (tasks_repo, jira_project, default_issue_type, tasks_path) = match tasks_kind {
+        BackendKind::Github | BackendKind::Gitlab => (
+            Some(prompts.input("TasksBackend repo", default_repo.as_deref())?),
+            None,
+            None,
+            None,
+        ),
+        BackendKind::Jira => (
+            None,
+            Some(prompts.input("JiraProject", Some("org/PROJ"))?),
+            match prompts.input("Default issue type", Some("Task"))? {
+                value if value.trim().is_empty() => None,
+                value => Some(value),
+            },
+            None,
+        ),
+        BackendKind::Local => (None, None, None, default_path.clone()),
+    };
+
     let board_default = config
         .boards
         .first()
         .map(|board| board.name.as_str())
         .unwrap_or("personal");
     let default_board = Some(prompts.input("Default board", Some(board_default))?);
-
-    let path = if backend == Backend::Local {
-        default_path
-    } else {
-        None
-    };
-    let mut backend_config = BackendConfig {
+    let derived_label = repo_project_label::derive_default(
+        origin_tail.as_deref(),
+        cwd.file_name().unwrap_or("project"),
+    );
+    let mut repo_project = RepoProject {
         name,
-        backend,
-        host,
-        repo,
+        vc_backend: VCBackendSpec {
+            kind: vc_kind,
+            host: vc_host,
+            repo: vc_repo,
+            path: default_path.clone(),
+        },
+        tasks_backend: TasksBackendSpec {
+            kind: tasks_kind.clone(),
+            host: tasks_host.clone(),
+            repo: tasks_repo,
+            jira_project: jira_project.clone(),
+            default_issue_type,
+            path: tasks_path,
+        },
         default_board,
         default_org: None,
-        path,
-        vc: None,
-        default_issue_type: None,
         key: None,
+        repo_project_label: None,
     };
-    validate_new_backend(config, &backend_config)?;
-    finalize_backend_registration(config, &mut backend_config, Some(prompts), ai)?;
-    config.backends.push(backend_config.clone());
-    Ok(backend_config)
+
+    let shared_jira = tasks_kind == BackendKind::Jira
+        && config.projects.iter().any(|existing| {
+            existing.tasks_backend.kind == BackendKind::Jira
+                && existing.tasks_backend.host == tasks_host
+                && existing.tasks_backend.jira_project == jira_project
+        });
+    // `repo_project_label` is only meaningful for *shared* Jira projects —
+    // it partitions one `jira_project` across multiple RepoProjects. Setting
+    // it on a solo Jira RepoProject would silently narrow `list_issues` JQL
+    // to `AND labels = "<label>"`, hiding every pre-existing Jira issue that
+    // lacks the synthetic label. So we only populate the label when:
+    //   - the user explicitly passed `--repo-project-label`, OR
+    //   - another RepoProject already registered for the same
+    //     `(tasks_host, jira_project)` (shared mode, prompt the user).
+    // For non-Jira TasksBackends the override flag is rejected and the field
+    // stays `None`.
+    if tasks_kind == BackendKind::Jira {
+        let final_label: Option<String> = if let Some(raw) = repo_project_label_override {
+            Some(
+                repo_project_label::normalize_user_input(&raw).ok_or_else(|| {
+                    RiptskError::Config(format!(
+                        "--repo-project-label '{raw}' sanitizes to an empty suffix after '{}'",
+                        repo_project_label::LABEL_PREFIX
+                    ))
+                })?,
+            )
+        } else if shared_jira {
+            let answer = prompts.input("Repo-project label", derived_label.as_deref())?;
+            repo_project_label::normalize_user_input(&answer)
+        } else {
+            None
+        };
+        if let Some(label) = final_label {
+            repo_project.repo_project_label = Some(deduplicate_default_label(
+                config,
+                cwd,
+                label,
+                tasks_host.as_deref(),
+                jira_project.as_deref(),
+            ));
+        }
+    } else if repo_project_label_override.is_some() {
+        return Err(RiptskError::Config(
+            "--repo-project-label is only valid when the TasksBackend is Jira".into(),
+        ));
+    }
+
+    validate_new_repo_project(config, &repo_project)?;
+    finalize_repo_project_registration(config, &mut repo_project, Some(prompts), ai)?;
+    config.projects.push(repo_project.clone());
+    Ok(repo_project)
+}
+
+fn select_backend_kind(
+    prompts: &dyn PromptBackend,
+    prompt: &str,
+    options: &[&str],
+    default: BackendKind,
+) -> Result<BackendKind, RiptskError> {
+    let items = options
+        .iter()
+        .map(|item| item.to_string())
+        .collect::<Vec<_>>();
+    let default_index = options
+        .iter()
+        .position(|item| *item == default.as_str())
+        .unwrap_or(0);
+    let selected = prompts.select(prompt, &items, default_index)?;
+    Ok(match selected.as_str() {
+        "github" => BackendKind::Github,
+        "gitlab" => BackendKind::Gitlab,
+        "jira" => BackendKind::Jira,
+        _ => BackendKind::Local,
+    })
 }
 
 pub(crate) fn suggest_key_with_ai(
@@ -439,8 +583,8 @@ pub(crate) fn suggest_key_with_ai(
 
 pub(crate) fn resolve_key_conflict_interactive(
     prompts: &dyn PromptBackend,
-    new_backend: &BackendConfig,
-    conflicting: &BackendConfig,
+    new_repo_project: &RepoProject,
+    conflicting: &RepoProject,
     attempted: &str,
     ai_default: Option<&str>,
     existing_keys: &[String],
@@ -449,37 +593,24 @@ pub(crate) fn resolve_key_conflict_interactive(
         "project key collision: attempted \"{attempted}\" is already used by '{}'",
         conflicting.name
     ));
-    eprintln!("Conflicting project:");
+    eprintln!("Conflicting RepoProject:");
     eprintln!("  name:  {}", conflicting.name);
-    eprintln!("  type:  {}", conflicting.backend.as_str());
-    if let Some(host) = &conflicting.host {
+    eprintln!("  tasks: {}", conflicting.tasks_backend.kind.as_str());
+    if let Some(host) = &conflicting.tasks_backend.host {
         eprintln!("  host:  {host}");
     }
-    if let Some(repo) = &conflicting.repo {
+    if let Some(repo) = &conflicting.tasks_backend.repo {
         eprintln!("  repo:  {repo}");
     }
-    if let Some(path) = &conflicting.path {
-        eprintln!("  path:  {path}");
+    if let Some(jira_project) = &conflicting.tasks_backend.jira_project {
+        eprintln!("  jira_project:  {jira_project}");
     }
-    if let Some(key) = &conflicting.key {
-        eprintln!("  key:   {key}");
-    }
-    eprintln!("New project:");
-    eprintln!("  name:  {}", new_backend.name);
-    eprintln!("  type:  {}", new_backend.backend.as_str());
-    if let Some(host) = &new_backend.host {
-        eprintln!("  host:  {host}");
-    }
-    if let Some(repo) = &new_backend.repo {
-        eprintln!("  repo:  {repo}");
-    }
-    if let Some(path) = &new_backend.path {
-        eprintln!("  path:  {path}");
-    }
+    eprintln!("New RepoProject:");
+    eprintln!("  name:  {}", new_repo_project.name);
+    eprintln!("  tasks: {}", new_repo_project.tasks_backend.kind.as_str());
 
     let fallback_suggestion = numeric_suffix_suggestion(attempted, existing_keys);
     let default_value = ai_default.unwrap_or(&fallback_suggestion);
-
     loop {
         let input = prompts.input("Enter a unique project key", Some(default_value))?;
         match validate_user_key(&input, existing_keys) {
@@ -489,41 +620,38 @@ pub(crate) fn resolve_key_conflict_interactive(
     }
 }
 
-fn finalize_backend_registration(
+fn finalize_repo_project_registration(
     config: &Config,
-    new_backend: &mut BackendConfig,
+    new_repo_project: &mut RepoProject,
     prompts: Option<&dyn PromptBackend>,
     ai: Option<&dyn AiBackend>,
 ) -> Result<(), RiptskError> {
-    let new_group = issue_ids::logical_group_identity(new_backend);
+    let new_group = issue_ids::logical_group_identity(new_repo_project);
 
-    // If the new backend belongs to the same logical project as an existing
-    // one, reuse that project's key so every entry resolves to the same
-    // effective key at runtime.
     if let Some(sibling) = config
-        .backends
+        .projects
         .iter()
-        .find(|backend| issue_ids::logical_group_identity(backend) == new_group)
+        .find(|repo_project| issue_ids::logical_group_identity(repo_project) == new_group)
     {
-        new_backend.key = Some(issue_ids::effective_key(sibling));
+        new_repo_project.key = Some(issue_ids::effective_key(sibling));
         return Ok(());
     }
 
-    let derived = issue_ids::derive_default_key(new_backend);
+    let derived = issue_ids::derive_default_key(new_repo_project);
     let mut existing_keys = Vec::new();
     let mut conflicting = None;
-    for backend in &config.backends {
-        if issue_ids::logical_group_identity(backend) == new_group {
+    for repo_project in &config.projects {
+        if issue_ids::logical_group_identity(repo_project) == new_group {
             continue;
         }
-        let key = issue_ids::effective_key(backend);
+        let key = issue_ids::effective_key(repo_project);
         if key == derived && conflicting.is_none() {
-            conflicting = Some(backend);
+            conflicting = Some(repo_project);
         }
         existing_keys.push(key);
     }
     if conflicting.is_none() {
-        new_backend.key = Some(derived);
+        new_repo_project.key = Some(derived);
         return Ok(());
     }
 
@@ -535,56 +663,86 @@ fn finalize_backend_registration(
         let ai_default = ai.and_then(|backend| {
             suggest_key_with_ai(
                 backend,
-                backend_key_source_name(new_backend),
-                new_backend.backend.as_str(),
+                backend_key_source_name(new_repo_project),
+                new_repo_project.tasks_backend.kind.as_str(),
                 &existing_keys,
             )
         });
         let resolved = resolve_key_conflict_interactive(
             prompts,
-            new_backend,
+            new_repo_project,
             conflicting,
             &derived,
             ai_default.as_deref(),
             &existing_keys,
         )?;
-        new_backend.key = Some(resolved);
+        new_repo_project.key = Some(resolved);
         return Ok(());
     }
 
-    Err(RiptskError::KeyCollision(Box::new(
-        crate::error::ProjectKeyCollision {
-            attempted_key: derived,
-            new_project: crate::error::ProjectKeyProjectMeta {
-                name: new_backend.name.clone(),
-                backend: new_backend.backend.as_str().to_owned(),
-                host: new_backend.host.clone(),
-                repo: new_backend.repo.clone(),
-                path: new_backend.path.clone(),
-                existing_key: new_backend.key.clone(),
-            },
-            conflicting_project: crate::error::ProjectKeyProjectMeta {
-                name: conflicting.name.clone(),
-                backend: conflicting.backend.as_str().to_owned(),
-                host: conflicting.host.clone(),
-                repo: conflicting.repo.clone(),
-                path: conflicting.path.clone(),
-                existing_key: conflicting.key.clone(),
-            },
-        },
-    )))
+    Err(RiptskError::KeyCollision(Box::new(ProjectKeyCollision {
+        attempted_key: derived,
+        new_project: project_meta(new_repo_project),
+        conflicting_project: project_meta(conflicting),
+    })))
 }
 
-fn backend_key_source_name(backend: &BackendConfig) -> &str {
-    match backend.backend {
-        Backend::Github | Backend::Gitlab | Backend::Jira => backend
-            .repo
-            .as_deref()
-            .and_then(|repo| repo.rsplit('/').next())
-            .filter(|value| !value.is_empty())
-            .unwrap_or(backend.name.as_str()),
-        Backend::Local => backend.name.as_str(),
-    }
+fn backend_key_source_name(repo_project: &RepoProject) -> &str {
+    repo_project
+        .tasks_backend
+        .jira_project
+        .as_deref()
+        .and_then(|jira_project| jira_project.rsplit('/').next())
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            repo_project
+                .vc_backend
+                .repo
+                .as_deref()
+                .and_then(|repo| repo.rsplit('/').next())
+                .filter(|value| !value.is_empty())
+        })
+        .unwrap_or(repo_project.name.as_str())
+}
+
+fn deduplicate_default_label(
+    config: &Config,
+    cwd: &Utf8Path,
+    label: String,
+    jira_host: Option<&str>,
+    jira_project: Option<&str>,
+) -> String {
+    let temp_repo_project = RepoProject {
+        name: "__new__".into(),
+        vc_backend: VCBackendSpec {
+            kind: BackendKind::Local,
+            host: None,
+            repo: None,
+            path: None,
+        },
+        tasks_backend: TasksBackendSpec {
+            kind: if jira_project.is_some() {
+                BackendKind::Jira
+            } else {
+                BackendKind::Local
+            },
+            host: jira_host.map(str::to_owned),
+            repo: None,
+            jira_project: jira_project.map(str::to_owned),
+            default_issue_type: None,
+            path: None,
+        },
+        default_board: None,
+        default_org: None,
+        key: None,
+        repo_project_label: Some(label.clone()),
+    };
+    repo_project_label::deduplicate_within_jira_project(
+        &label,
+        &temp_repo_project,
+        config.projects.iter(),
+        cwd.parent().and_then(|parent| parent.file_name()),
+    )
 }
 
 fn stdin_is_terminal() -> bool {
@@ -596,16 +754,12 @@ fn stdout_is_terminal() -> bool {
 }
 
 fn numeric_suffix_suggestion(attempted: &str, existing: &[String]) -> String {
-    // Reserve room for `-N` (up to three digits) so the suggested value still
-    // fits inside `MAX_KEY_LEN` once the suffix is appended.
     let reserved = "-999".len();
     let max_prefix_len = issue_ids::MAX_KEY_LEN.saturating_sub(reserved);
     let mut prefix = attempted;
     if prefix.len() > max_prefix_len {
         prefix = &prefix[..max_prefix_len];
     }
-    // Trim any trailing '-' that a naive slice may leave behind so the result
-    // still passes `validate_user_key`.
     let prefix = prefix.trim_end_matches('-');
     for number in 2u32..1000 {
         let candidate = format!("{prefix}-{number}");
@@ -617,20 +771,14 @@ fn numeric_suffix_suggestion(attempted: &str, existing: &[String]) -> String {
 }
 
 fn validate_user_key(raw: &str, existing: &[String]) -> Result<String, String> {
-    // Silently trim the user's input so enter-at-the-prompt typos don't count
-    // as hard errors, then delegate syntactic validation to the shared helper
-    // so that interactively accepted keys cannot be rejected later by
-    // `save_config()`.
     let trimmed = raw.trim();
-    issue_ids::validate_explicit_key_syntax(trimmed).map_err(|message| message.to_string())?;
+    issue_ids::validate_explicit_key_syntax(trimmed)?;
     if existing.iter().any(|key| key == trimmed) {
         return Err(format!("key '{trimmed}' is already in use"));
     }
     Ok(trimmed.to_owned())
 }
 
-/// Returns true if `cwd` is exactly `$HOME` (canonicalized comparison).
-/// Directories *under* `$HOME` are allowed; only `$HOME` itself is excluded.
 fn is_home_dir(cwd: &Utf8Path) -> bool {
     let Some(home) = std::env::var_os("HOME") else {
         return false;
@@ -649,7 +797,6 @@ fn path_is_same(a: &str, b: &str) -> bool {
     a_canon == b_canon
 }
 
-/// Returns the git top-level directory for `cwd`, or `None` if not in a git repo.
 fn git_toplevel(cwd: &Utf8Path) -> Result<Option<String>, RiptskError> {
     let output = Command::new("git")
         .arg("-C")
@@ -687,138 +834,113 @@ fn is_inside_work_tree(cwd: &Utf8Path) -> Result<bool, RiptskError> {
     Ok(output.status.success())
 }
 
-fn validate_new_backend(config: &Config, backend: &BackendConfig) -> Result<(), RiptskError> {
+fn validate_new_repo_project(
+    config: &Config,
+    repo_project: &RepoProject,
+) -> Result<(), RiptskError> {
     if config
-        .backends
+        .projects
         .iter()
-        .any(|candidate| candidate.name == backend.name)
+        .any(|candidate| candidate.name == repo_project.name)
     {
         return Err(RiptskError::Config(format!(
-            "backend name already exists: {}",
-            backend.name
+            "RepoProject name already exists: {}",
+            repo_project.name
         )));
     }
+    if repo_project.vc_backend.kind == BackendKind::Jira {
+        return Err(RiptskError::Config(format!(
+            "RepoProject '{}' cannot use Jira as a VCBackend",
+            repo_project.name
+        )));
+    }
+    if repo_project.tasks_backend.kind == BackendKind::Jira {
+        let host = repo_project
+            .tasks_backend
+            .host
+            .as_deref()
+            .unwrap_or_default();
+        if !host.starts_with("https://") {
+            return Err(RiptskError::Config(format!(
+                "Jira TasksBackend for RepoProject '{}' requires https:// host",
+                repo_project.name
+            )));
+        }
+        let jira_project = repo_project
+            .tasks_backend
+            .jira_project
+            .as_deref()
+            .unwrap_or_default();
+        if jira_project.is_empty() || !jira_project.contains('/') {
+            return Err(RiptskError::Config(format!(
+                "Jira TasksBackend for RepoProject '{}' requires jira_project in org/PROJECT_KEY format",
+                repo_project.name
+            )));
+        }
+    }
+    if let Some(label) = repo_project.repo_project_label.as_deref() {
+        repo_project_label::validate(label)?;
+    }
     Ok(())
+}
+
+fn project_meta(repo_project: &RepoProject) -> ProjectKeyProjectMeta {
+    ProjectKeyProjectMeta {
+        name: repo_project.name.clone(),
+        backend: repo_project.tasks_backend.kind.as_str().to_owned(),
+        host: repo_project
+            .tasks_backend
+            .host
+            .clone()
+            .or_else(|| repo_project.vc_backend.host.clone()),
+        repo: repo_project
+            .tasks_backend
+            .repo
+            .clone()
+            .or_else(|| repo_project.tasks_backend.jira_project.clone())
+            .or_else(|| repo_project.vc_backend.repo.clone()),
+        path: repo_project
+            .vc_backend
+            .path
+            .clone()
+            .or_else(|| repo_project.tasks_backend.path.clone()),
+        existing_key: repo_project.key.clone(),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        deduplicate_name, detect_from_cwd, finalize_backend_registration, infer_type, is_home_dir,
-        normalize_url, numeric_suffix_suggestion, path_is_same, register_project_auto,
-        resolve_key_conflict_interactive, split_host_repo, suggest_key_with_ai,
+        deduplicate_name, detect_from_cwd, infer_type, normalize_url, register_project_auto,
+        split_host_repo,
     };
-    use crate::adapters::ai::{AiBackend, GeneratedIssueContent, TriageSuggestion};
-    use crate::adapters::prompts::PromptBackend;
     use crate::config::default_config;
-    use crate::error::RiptskError;
-    use crate::models::{Backend, BackendConfig};
+    use crate::models::{BackendKind, RepoProject, TasksBackendSpec, VCBackendSpec};
+    use crate::services::repo_project_label::validate as validate_label;
     use camino::Utf8PathBuf;
-    use std::cell::RefCell;
-    use std::collections::VecDeque;
     use tempfile::tempdir;
 
-    struct FakePrompts {
-        inputs: RefCell<VecDeque<String>>,
-    }
-
-    impl FakePrompts {
-        fn new(inputs: Vec<&str>) -> Self {
-            Self {
-                inputs: RefCell::new(inputs.into_iter().map(str::to_owned).collect()),
-            }
-        }
-    }
-
-    impl PromptBackend for FakePrompts {
-        fn input(&self, _prompt: &str, _default: Option<&str>) -> Result<String, RiptskError> {
-            self.inputs
-                .borrow_mut()
-                .pop_front()
-                .ok_or_else(|| RiptskError::General("missing prompt input".into()))
-        }
-
-        fn confirm(&self, _prompt: &str, _default: bool) -> Result<bool, RiptskError> {
-            unimplemented!()
-        }
-
-        fn select(
-            &self,
-            _prompt: &str,
-            _items: &[String],
-            _default: usize,
-        ) -> Result<String, RiptskError> {
-            unimplemented!()
-        }
-    }
-
-    struct FakeAiBackend {
-        suggestion: Option<String>,
-        should_error: bool,
-    }
-
-    impl AiBackend for FakeAiBackend {
-        fn generate_issue_content(
-            &self,
-            _context: &str,
-        ) -> Result<GeneratedIssueContent, RiptskError> {
-            unimplemented!()
-        }
-
-        fn generate_body(&self, _context: &str) -> Result<String, RiptskError> {
-            unimplemented!()
-        }
-
-        fn suggest_project_key(
-            &self,
-            _repo_name: &str,
-            _backend_type: &str,
-            _existing_keys: &[String],
-        ) -> Result<String, RiptskError> {
-            if self.should_error {
-                Err(RiptskError::General("nope".into()))
-            } else {
-                Ok(self.suggestion.clone().unwrap_or_default())
-            }
-        }
-
-        fn generate_pr_description(&self, _context: &str) -> Result<String, RiptskError> {
-            unimplemented!()
-        }
-
-        fn triage(&self, _issue_context: &str) -> Result<TriageSuggestion, RiptskError> {
-            unimplemented!()
-        }
-
-        fn summarize(&self, _issues: &str) -> Result<String, RiptskError> {
-            unimplemented!()
-        }
-
-        fn ask(&self, _question: &str, _context: &str) -> Result<String, RiptskError> {
-            unimplemented!()
-        }
-
-        fn update_pr_description(&self, _context: &str) -> Result<String, RiptskError> {
-            unimplemented!()
-        }
-
-        fn generate_commit_message(&self, _diff: &str) -> Result<String, RiptskError> {
-            unimplemented!()
-        }
-    }
-
-    fn backend(kind: Backend, name: &str, repo: Option<&str>, key: Option<&str>) -> BackendConfig {
-        BackendConfig {
+    fn local_repo_project(name: &str, path: &str) -> RepoProject {
+        RepoProject {
             name: name.into(),
-            backend: kind,
-            host: None,
-            repo: repo.map(str::to_owned),
+            vc_backend: VCBackendSpec {
+                kind: BackendKind::Local,
+                host: None,
+                repo: None,
+                path: Some(path.into()),
+            },
+            tasks_backend: TasksBackendSpec {
+                kind: BackendKind::Local,
+                host: None,
+                repo: None,
+                jira_project: None,
+                default_issue_type: None,
+                path: Some(path.into()),
+            },
             default_board: Some("personal".into()),
             default_org: None,
-            path: None,
-            vc: None,
-            default_issue_type: None,
-            key: key.map(str::to_owned),
+            key: Some("LOCAL".into()),
+            repo_project_label: None,
         }
     }
 
@@ -836,9 +958,9 @@ mod tests {
 
     #[test]
     fn infers_remote_type_from_host() {
-        assert_eq!(infer_type("github.com"), Backend::Github);
-        assert_eq!(infer_type("gitlab.example.com"), Backend::Gitlab);
-        assert_eq!(infer_type("codeberg.org"), Backend::Local);
+        assert_eq!(infer_type("github.com"), BackendKind::Github);
+        assert_eq!(infer_type("gitlab.example.com"), BackendKind::Gitlab);
+        assert_eq!(infer_type("codeberg.org"), BackendKind::Local);
     }
 
     #[test]
@@ -854,375 +976,82 @@ mod tests {
     }
 
     #[test]
-    fn split_host_repo_handles_ported_urls() {
-        // ssh://git@host:2222/group/repo normalizes to host:2222:group/repo
-        assert_eq!(
-            split_host_repo("gitlab.example.com:2222:group/repo"),
-            Some(("gitlab.example.com:2222", "group/repo"))
-        );
-        // https://host:8443/group/repo normalizes to host:8443:group/repo
-        assert_eq!(
-            split_host_repo("gitlab.example.com:8443:group/repo"),
-            Some(("gitlab.example.com:8443", "group/repo"))
-        );
-    }
-
-    #[test]
-    fn is_home_dir_matches_actual_home() {
-        if let Ok(home) = std::env::var("HOME") {
-            let path = Utf8PathBuf::from(&home);
-            assert!(is_home_dir(&path));
-        }
-    }
-
-    #[test]
-    fn is_home_dir_rejects_subdir() {
-        if let Ok(home) = std::env::var("HOME") {
-            let subdir = Utf8PathBuf::from(format!("{home}/some-subdir"));
-            assert!(!is_home_dir(&subdir));
-        }
-    }
-
-    #[test]
-    fn path_is_same_handles_identical_paths() {
-        let temp = tempdir().expect("temp dir");
-        let path = temp.path().to_string_lossy().to_string();
-        assert!(path_is_same(&path, &path));
-    }
-
-    #[test]
-    fn register_auto_non_git_creates_local_backend() {
-        let temp = tempdir().expect("temp dir");
-        let plain_dir = temp.path().join("my-proj");
-        std::fs::create_dir_all(&plain_dir).expect("create dir");
-        let cwd = Utf8PathBuf::from_path_buf(plain_dir.clone()).expect("utf8");
-        let mut config = default_config();
-
-        let result = register_project_auto(&cwd, &mut config, None, None).expect("register");
-
-        assert!(result.is_some());
-        let backend = result.unwrap();
-        assert_eq!(backend.backend, Backend::Local);
-        assert_eq!(backend.name, "my-proj");
-        assert!(backend.path.is_some());
-        assert!(backend.host.is_none());
-        assert!(backend.repo.is_none());
-        assert_eq!(backend.key.as_deref(), Some("MYPROJ"));
-    }
-
-    #[test]
-    fn register_auto_skips_home_dir() {
-        let temp = tempdir().expect("temp dir");
-        let cwd = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).expect("utf8");
-        let mut config = default_config();
-
-        // Pretend this temp dir is $HOME
-        let old_home = std::env::var("HOME").ok();
-        // SAFETY: test is single-threaded; restoring HOME immediately after.
-        unsafe { std::env::set_var("HOME", temp.path()) };
-        let result = register_project_auto(&cwd, &mut config, None, None).expect("register");
-        match old_home {
-            Some(h) => unsafe { std::env::set_var("HOME", h) },
-            None => unsafe { std::env::remove_var("HOME") },
-        }
-
-        assert!(result.is_none(), "should not register $HOME as a project");
-    }
-
-    #[test]
     fn detect_from_cwd_matches_non_git_by_path() {
         let temp = tempdir().expect("temp dir");
-        let plain_dir = temp.path().join("my-proj");
-        std::fs::create_dir_all(&plain_dir).expect("create dir");
-        let cwd = Utf8PathBuf::from_path_buf(plain_dir.clone()).expect("utf8");
-        let canon = std::fs::canonicalize(&plain_dir)
-            .expect("canonicalize")
-            .to_string_lossy()
-            .to_string();
-
+        let cwd = Utf8PathBuf::from_path_buf(temp.path().join("worktree")).expect("utf8 path");
+        std::fs::create_dir_all(cwd.as_std_path()).expect("cwd");
         let mut config = default_config();
-        config.backends.push(BackendConfig {
-            name: "my-proj".into(),
-            backend: Backend::Local,
-            host: None,
-            repo: None,
-            default_board: Some("personal".into()),
-            default_org: None,
-            path: Some(canon),
-            vc: None,
-            default_issue_type: None,
-            key: None,
-        });
+        config
+            .projects
+            .push(local_repo_project("local", cwd.as_str()));
 
         let detected = detect_from_cwd(&cwd, &config).expect("detect");
-        assert!(detected.is_some());
-        assert_eq!(detected.unwrap().name, "my-proj");
-    }
-
-    #[test]
-    fn detect_from_cwd_url_beats_ancestor_path() {
-        // Regression: a registered remote backend must win over a parent local backend
-        // when the child directory has a git remote matching the remote backend.
-        let temp = tempdir().expect("temp dir");
-        let parent_dir = temp.path().join("projects");
-        let child_dir = parent_dir.join("my-repo");
-        std::fs::create_dir_all(&child_dir).expect("create dirs");
-
-        // Set up a real git repo with a remote URL in child_dir
-        let status = std::process::Command::new("git")
-            .args(["init", "--quiet"])
-            .arg(&child_dir)
-            .status()
-            .expect("git init");
-        assert!(status.success());
-        let status = std::process::Command::new("git")
-            .arg("-C")
-            .arg(&child_dir)
-            .args([
-                "remote",
-                "add",
-                "origin",
-                "https://github.com/user/my-repo.git",
-            ])
-            .status()
-            .expect("git remote add");
-        assert!(status.success());
-
-        let parent_canon = std::fs::canonicalize(&parent_dir)
-            .expect("canonicalize")
-            .to_string_lossy()
-            .to_string();
-
-        let mut config = default_config();
-        // Parent local backend registered at ancestor path
-        config.backends.push(BackendConfig {
-            name: "projects".into(),
-            backend: Backend::Local,
-            host: None,
-            repo: None,
-            default_board: Some("personal".into()),
-            default_org: None,
-            path: Some(parent_canon),
-            vc: None,
-            default_issue_type: None,
-            key: None,
-        });
-        // Remote backend registered by URL — should win over parent path
-        config.backends.push(BackendConfig {
-            name: "my-repo".into(),
-            backend: Backend::Github,
-            host: Some("https://github.com".into()),
-            repo: Some("user/my-repo".into()),
-            default_board: Some("personal".into()),
-            default_org: None,
-            path: None,
-            vc: None,
-            default_issue_type: None,
-            key: None,
-        });
-
-        let cwd = Utf8PathBuf::from_path_buf(child_dir).expect("utf8");
-        let detected = detect_from_cwd(&cwd, &config).expect("detect");
-        assert!(detected.is_some());
-        // URL match must win over ancestor path match
-        assert_eq!(detected.unwrap().name, "my-repo");
+        assert_eq!(detected.expect("detected").name, "local");
     }
 
     #[test]
     fn deduplicate_name_appends_parent_on_collision() {
         let temp = tempdir().expect("temp dir");
-        let child = temp.path().join("parent").join("myapp");
-        std::fs::create_dir_all(&child).expect("create dirs");
-        let cwd = Utf8PathBuf::from_path_buf(child).expect("utf8");
-
+        let cwd =
+            Utf8PathBuf::from_path_buf(temp.path().join("parent").join("myapp")).expect("utf8 cwd");
+        std::fs::create_dir_all(cwd.as_std_path()).expect("cwd");
         let mut config = default_config();
-        config.backends.push(BackendConfig {
-            name: "myapp".into(),
-            backend: Backend::Local,
-            host: None,
-            repo: None,
-            default_board: None,
-            default_org: None,
-            path: Some("/some/other/myapp".into()),
-            vc: None,
-            default_issue_type: None,
-            key: None,
-        });
+        config
+            .projects
+            .push(local_repo_project("myapp", "/tmp/myapp"));
 
         let name = deduplicate_name("myapp", &cwd, &config);
-        assert_eq!(name, Some("parent-myapp".into()));
+        assert_eq!(name.as_deref(), Some("parent-myapp"));
     }
 
     #[test]
-    fn deduplicate_name_returns_none_when_exhausted() {
+    fn register_auto_non_git_creates_local_project() {
         let temp = tempdir().expect("temp dir");
-        let child = temp.path().join("parent").join("myapp");
-        std::fs::create_dir_all(&child).expect("create dirs");
-        let cwd = Utf8PathBuf::from_path_buf(child).expect("utf8");
-
+        let cwd = Utf8PathBuf::from_path_buf(temp.path().join("repo")).expect("utf8 cwd");
+        std::fs::create_dir_all(cwd.as_std_path()).expect("cwd");
         let mut config = default_config();
-        config.backends.push(BackendConfig {
-            name: "myapp".into(),
-            backend: Backend::Local,
-            host: None,
-            repo: None,
-            default_board: None,
-            default_org: None,
-            path: Some("/some/other/myapp".into()),
-            vc: None,
-            default_issue_type: None,
-            key: None,
-        });
-        config.backends.push(BackendConfig {
-            name: "parent-myapp".into(),
-            backend: Backend::Local,
-            host: None,
-            repo: None,
-            default_board: None,
-            default_org: None,
-            path: Some("/some/other/parent-myapp".into()),
-            vc: None,
-            default_issue_type: None,
-            key: None,
-        });
 
-        let name = deduplicate_name("myapp", &cwd, &config);
-        assert_eq!(name, None);
+        let result = register_project_auto(&cwd, &mut config, None, None).expect("register");
+        let registered = result.expect("project");
+        assert_eq!(registered.vc_backend.kind, BackendKind::Local);
+        // Local/Local RepoProjects do not carry `repo_project_label` — that
+        // field is exclusively a Jira-shared-project partition concept.
+        assert_eq!(registered.repo_project_label, None);
+        assert_eq!(config.projects.len(), 1);
     }
 
     #[test]
-    fn suggest_key_with_ai_accepts_clean_value() {
-        let ai = FakeAiBackend {
-            suggestion: Some("RIPTSK".into()),
-            should_error: false,
-        };
-        let existing = vec!["OTHER".into()];
-        assert_eq!(
-            suggest_key_with_ai(&ai, "riptsk", "github", &existing),
-            Some("RIPTSK".into())
+    fn validate_repo_project_rejects_space_in_label() {
+        assert!(validate_label("has space").is_err());
+    }
+
+    #[test]
+    fn validate_repo_project_rejects_empty_label() {
+        assert!(validate_label("").is_err());
+    }
+
+    #[test]
+    fn validate_repo_project_rejects_quote_in_label() {
+        assert!(validate_label("has\"quote").is_err());
+    }
+
+    #[test]
+    fn validate_repo_project_rejects_over_255_chars() {
+        let long = format!(
+            "{}{}",
+            crate::services::repo_project_label::LABEL_PREFIX,
+            "a".repeat(crate::services::repo_project_label::MAX_LABEL_LEN)
         );
+        assert!(validate_label(&long).is_err());
     }
 
     #[test]
-    fn suggest_key_with_ai_sanitizes_output() {
-        let ai = FakeAiBackend {
-            suggestion: Some("riptsk!!!".into()),
-            should_error: false,
-        };
-        assert_eq!(
-            suggest_key_with_ai(&ai, "riptsk", "github", &[]),
-            Some("RIPTSK".into())
-        );
+    fn validate_repo_project_rejects_missing_prefix() {
+        assert!(validate_label("good-label").is_err());
     }
 
     #[test]
-    fn suggest_key_with_ai_rejects_collision_and_invalid() {
-        let taken = vec!["ALREADYTAKEN".into()];
-        let collision = FakeAiBackend {
-            suggestion: Some("ALREADY_TAKEN".into()),
-            should_error: false,
-        };
-        let invalid = FakeAiBackend {
-            suggestion: Some("!!!".into()),
-            should_error: false,
-        };
-        let erroring = FakeAiBackend {
-            suggestion: None,
-            should_error: true,
-        };
-        assert_eq!(
-            suggest_key_with_ai(&collision, "repo", "github", &taken),
-            None
-        );
-        assert_eq!(suggest_key_with_ai(&invalid, "repo", "github", &[]), None);
-        assert_eq!(suggest_key_with_ai(&erroring, "repo", "github", &[]), None);
-    }
-
-    #[test]
-    fn resolve_key_conflict_interactive_accepts_ai_default_value() {
-        let prompts = FakePrompts::new(vec!["RIPTSK"]);
-        let new_backend = backend(Backend::Github, "new", Some("owner/riptsk"), None);
-        let conflicting = backend(
-            Backend::Github,
-            "existing",
-            Some("other/riptsk"),
-            Some("RIPTSK"),
-        );
-        let resolved = resolve_key_conflict_interactive(
-            &prompts,
-            &new_backend,
-            &conflicting,
-            "RIPTSK",
-            Some("RIPTSK"),
-            &["OTHER".into()],
-        )
-        .expect("resolve");
-        assert_eq!(resolved, "RIPTSK");
-    }
-
-    #[test]
-    fn resolve_key_conflict_interactive_loops_on_invalid_inputs() {
-        let prompts = FakePrompts::new(vec!["lower-case", "UPPERCASE"]);
-        let new_backend = backend(Backend::Github, "new", Some("owner/new"), None);
-        let conflicting = backend(Backend::Github, "existing", Some("other/new"), Some("NEW"));
-        let resolved = resolve_key_conflict_interactive(
-            &prompts,
-            &new_backend,
-            &conflicting,
-            "NEW",
-            None,
-            &["NEW".into()],
-        )
-        .expect("resolve");
-        assert_eq!(resolved, "UPPERCASE");
-    }
-
-    #[test]
-    fn resolve_key_conflict_interactive_retries_on_duplicate() {
-        let prompts = FakePrompts::new(vec!["USED", "UNUSED"]);
-        let new_backend = backend(Backend::Github, "new", Some("owner/new"), None);
-        let conflicting = backend(Backend::Github, "existing", Some("other/new"), Some("NEW"));
-        let resolved = resolve_key_conflict_interactive(
-            &prompts,
-            &new_backend,
-            &conflicting,
-            "NEW",
-            None,
-            &["USED".into()],
-        )
-        .expect("resolve");
-        assert_eq!(resolved, "UNUSED");
-    }
-
-    #[test]
-    fn numeric_suffix_suggestion_uses_next_free_number() {
-        let existing = vec!["RIPTSK".into(), "RIPTSK-2".into()];
-        assert_eq!(numeric_suffix_suggestion("RIPTSK", &existing), "RIPTSK-3");
-    }
-
-    #[test]
-    fn finalize_backend_registration_sets_derived_key_when_free() {
-        let config = default_config();
-        let mut new_backend = backend(Backend::Github, "riptsk", Some("owner/riptsk"), None);
-        finalize_backend_registration(&config, &mut new_backend, None, None).expect("finalize");
-        assert_eq!(new_backend.key.as_deref(), Some("RIPTSK"));
-    }
-
-    #[test]
-    fn finalize_backend_registration_returns_collision_without_prompts() {
-        let mut config = default_config();
-        config.backends.push(backend(
-            Backend::Github,
-            "existing",
-            Some("owner/riptsk"),
-            None,
-        ));
-        let before = config.backends.len();
-        let mut new_backend = backend(Backend::Github, "new", Some("other/riptsk"), None);
-        let error = finalize_backend_registration(&config, &mut new_backend, None, None)
-            .expect_err("collision");
-        assert!(matches!(error, RiptskError::KeyCollision(_)));
-        assert!(new_backend.key.is_none());
-        assert_eq!(config.backends.len(), before);
+    fn validate_repo_project_accepts_prefixed_label() {
+        assert!(validate_label("proj::good-label").is_ok());
     }
 }

--- a/src/services/repo_project_label.rs
+++ b/src/services/repo_project_label.rs
@@ -1,0 +1,314 @@
+//! Derivation, sanitization, and validation for `RepoProject.repo_project_label`.
+//!
+//! Labels carry a fixed `proj::` prefix so a Jira label ring clearly identifies
+//! which tags reference a RepoProject (vs. a status, component, or freeform
+//! tag). Derived labels always have the prefix; user input is normalized to
+//! the prefixed form.
+
+use crate::error::RiptskError;
+use crate::models::{BackendKind, RepoProject};
+
+pub const MAX_LABEL_LEN: usize = 255;
+
+/// Fixed prefix for every `repo_project_label`. Identifies a Jira label as a
+/// RepoProject reference.
+pub const LABEL_PREFIX: &str = "proj::";
+
+/// Derive a default label from the git origin URL's last path segment (minus
+/// `.git`), falling back to `cwd_basename` when no remote is available. The
+/// return value carries the `proj::` prefix. Returns `None` if the sanitized
+/// suffix is empty (e.g. emoji-only or punctuation-only source).
+pub fn derive_default(origin_last_segment: Option<&str>, cwd_basename: &str) -> Option<String> {
+    let raw = origin_last_segment.unwrap_or(cwd_basename);
+    let suffix = sanitize(raw);
+    if suffix.is_empty() {
+        None
+    } else {
+        Some(format!("{LABEL_PREFIX}{suffix}"))
+    }
+}
+
+/// Normalize a user-supplied label value to the prefixed form. Accepts input
+/// that already starts with `proj::` (kept verbatim after validation) or a
+/// bare suffix (sanitized and prefixed). Returns `None` when normalization
+/// yields an empty suffix.
+pub fn normalize_user_input(raw: &str) -> Option<String> {
+    if let Some(suffix) = raw.strip_prefix(LABEL_PREFIX) {
+        if suffix.is_empty() {
+            None
+        } else {
+            Some(format!("{LABEL_PREFIX}{suffix}"))
+        }
+    } else {
+        let suffix = sanitize(raw);
+        if suffix.is_empty() {
+            None
+        } else {
+            Some(format!("{LABEL_PREFIX}{suffix}"))
+        }
+    }
+}
+
+/// Lowercase, replace separators with `-`, strip disallowed chars, collapse
+/// repeated `-`, and trim trailing `-`.
+pub fn sanitize(raw: &str) -> String {
+    let lowered = raw.trim_end_matches(".git").to_lowercase();
+    let mut buffer = String::with_capacity(lowered.len());
+    let mut last_was_dash = false;
+    for ch in lowered.chars() {
+        let mapped = if ch.is_ascii_alphanumeric() || ch == '_' {
+            Some(ch)
+        } else if matches!(ch, ' ' | '\t' | '.' | '/' | '\\' | '-') {
+            Some('-')
+        } else {
+            None
+        };
+
+        match mapped {
+            Some('-') => {
+                if !last_was_dash && !buffer.is_empty() {
+                    buffer.push('-');
+                    last_was_dash = true;
+                }
+            }
+            Some(c) => {
+                buffer.push(c);
+                last_was_dash = false;
+            }
+            None => {}
+        }
+    }
+
+    while buffer.ends_with('-') {
+        buffer.pop();
+    }
+
+    buffer
+}
+
+/// Validate a user-or-derived label. Enforces the `proj::` prefix, a
+/// non-empty suffix, the length bound, and the whitespace/quote ban.
+pub fn validate(label: &str) -> Result<(), RiptskError> {
+    if label.is_empty() {
+        return Err(RiptskError::Config(
+            "repo_project_label cannot be empty".into(),
+        ));
+    }
+    if label.len() > MAX_LABEL_LEN {
+        return Err(RiptskError::Config(format!(
+            "repo_project_label '{label}' exceeds {MAX_LABEL_LEN} chars"
+        )));
+    }
+    if label.chars().any(|c| c.is_whitespace() || c == '"') {
+        return Err(RiptskError::Config(format!(
+            "repo_project_label '{label}' must not contain whitespace or double quotes"
+        )));
+    }
+    let Some(suffix) = label.strip_prefix(LABEL_PREFIX) else {
+        return Err(RiptskError::Config(format!(
+            "repo_project_label '{label}' must start with '{LABEL_PREFIX}'"
+        )));
+    };
+    if suffix.is_empty() {
+        return Err(RiptskError::Config(format!(
+            "repo_project_label '{label}' is missing a suffix after '{LABEL_PREFIX}'"
+        )));
+    }
+    Ok(())
+}
+
+/// Deduplicate a derived label against other RepoProjects sharing the same Jira project.
+///
+/// The bare `derived` label is tried first; on collision we prefix with the
+/// current directory's parent name and re-check. If the prefixed candidate is
+/// also taken we fall through to numeric suffixes (`-2`, `-3`, ...) scoped to
+/// the same Jira project, so a third sibling registration cannot silently
+/// reuse a sibling's label.
+pub fn deduplicate_within_jira_project<'a>(
+    derived: &str,
+    new: &RepoProject,
+    existing: impl IntoIterator<Item = &'a RepoProject>,
+    cwd_parent_name: Option<&str>,
+) -> String {
+    let same_jira = |rp: &RepoProject| -> bool {
+        rp.tasks_backend.kind == BackendKind::Jira
+            && new.tasks_backend.kind == BackendKind::Jira
+            && rp.tasks_backend.host == new.tasks_backend.host
+            && rp.tasks_backend.jira_project == new.tasks_backend.jira_project
+    };
+    let siblings: Vec<&'a RepoProject> = existing.into_iter().filter(|rp| same_jira(rp)).collect();
+    let taken = |candidate: &str| -> bool {
+        siblings
+            .iter()
+            .any(|rp| rp.repo_project_label.as_deref() == Some(candidate))
+    };
+
+    if !taken(derived) {
+        return derived.to_owned();
+    }
+    let derived_suffix = derived.strip_prefix(LABEL_PREFIX).unwrap_or(derived);
+    let prefixed = |suffix: &str| format!("{LABEL_PREFIX}{suffix}");
+    if let Some(parent) = cwd_parent_name {
+        let suffix = sanitize(&format!("{parent}-{derived_suffix}"));
+        if !suffix.is_empty() {
+            let candidate = prefixed(&suffix);
+            if !taken(&candidate) {
+                return candidate;
+            }
+        }
+    }
+    // Final fallback: numeric suffix. Guaranteed to terminate because `siblings`
+    // is finite, so some `{derived}-N` for N in 2..=len+2 is free.
+    let mut n: usize = 2;
+    loop {
+        let suffix = sanitize(&format!("{derived_suffix}-{n}"));
+        let candidate = prefixed(&suffix);
+        if !suffix.is_empty() && !taken(&candidate) {
+            return candidate;
+        }
+        n += 1;
+        if n > siblings.len() + 2 {
+            // Defensive: should be unreachable under the invariant above.
+            return candidate;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        LABEL_PREFIX, MAX_LABEL_LEN, deduplicate_within_jira_project, derive_default,
+        normalize_user_input, sanitize, validate,
+    };
+    use crate::models::{BackendKind, RepoProject, TasksBackendSpec, VCBackendSpec};
+
+    fn repo_project(
+        name: &str,
+        label: Option<&str>,
+        host: Option<&str>,
+        jira_project: Option<&str>,
+    ) -> RepoProject {
+        RepoProject {
+            name: name.into(),
+            vc_backend: VCBackendSpec {
+                kind: BackendKind::Local,
+                host: None,
+                repo: None,
+                path: Some(format!("/tmp/{name}")),
+            },
+            tasks_backend: TasksBackendSpec {
+                kind: if jira_project.is_some() {
+                    BackendKind::Jira
+                } else {
+                    BackendKind::Local
+                },
+                host: host.map(str::to_owned),
+                repo: None,
+                jira_project: jira_project.map(str::to_owned),
+                default_issue_type: None,
+                path: None,
+            },
+            default_board: None,
+            default_org: None,
+            key: None,
+            repo_project_label: label.map(str::to_owned),
+        }
+    }
+
+    #[test]
+    fn sanitize_normalizes_common_cases() {
+        assert_eq!(sanitize("My Repo.git"), "my-repo");
+        assert_eq!(sanitize("owner/repo_name"), "owner-repo_name");
+        assert_eq!(sanitize("already---split"), "already-split");
+        assert_eq!(sanitize("UPPER.CASE"), "upper-case");
+        assert_eq!(sanitize(" weird / value "), "weird-value");
+    }
+
+    #[test]
+    fn derive_default_prefers_origin_segment_and_prepends_prefix() {
+        assert_eq!(
+            derive_default(Some("my-api.git"), "fallback").as_deref(),
+            Some("proj::my-api")
+        );
+        assert_eq!(
+            derive_default(None, "my-api").as_deref(),
+            Some("proj::my-api")
+        );
+    }
+
+    #[test]
+    fn derive_default_returns_none_when_suffix_sanitizes_to_empty() {
+        assert_eq!(derive_default(Some("!!!"), "???"), None);
+    }
+
+    #[test]
+    fn normalize_accepts_bare_suffix_and_prefixed_forms() {
+        assert_eq!(
+            normalize_user_input("my-api").as_deref(),
+            Some("proj::my-api")
+        );
+        assert_eq!(
+            normalize_user_input("proj::already").as_deref(),
+            Some("proj::already")
+        );
+        assert_eq!(normalize_user_input("proj::").as_deref(), None);
+        assert_eq!(normalize_user_input("!!!"), None);
+    }
+
+    #[test]
+    fn validate_rejects_bad_inputs() {
+        assert!(validate("").is_err());
+        assert!(validate("has space").is_err());
+        assert!(validate("has\"quote").is_err());
+        assert!(validate(&format!("{LABEL_PREFIX}{}", "a".repeat(MAX_LABEL_LEN))).is_err());
+        // No prefix → reject.
+        assert!(validate("good-label").is_err());
+        // Prefix only → reject.
+        assert!(validate("proj::").is_err());
+        // Prefixed, non-empty suffix, no forbidden chars → accept.
+        assert!(validate("proj::good-label").is_ok());
+    }
+
+    #[test]
+    fn deduplicate_scopes_to_matching_jira_project() {
+        let new = repo_project("new", None, Some("https://jira.example"), Some("org/PROJ"));
+        let existing = [repo_project(
+            "existing",
+            Some("proj::repo-a"),
+            Some("https://jira.example"),
+            Some("org/PROJ"),
+        )];
+        assert_eq!(
+            deduplicate_within_jira_project("proj::repo-a", &new, existing.iter(), Some("team")),
+            "proj::team-repo-a"
+        );
+    }
+
+    #[test]
+    fn deduplicate_falls_back_when_prefixed_candidate_also_taken() {
+        let new = repo_project("new", None, Some("https://jira.example"), Some("org/PROJ"));
+        let existing = [
+            repo_project(
+                "first",
+                Some("proj::repo-a"),
+                Some("https://jira.example"),
+                Some("org/PROJ"),
+            ),
+            repo_project(
+                "second",
+                Some("proj::team-repo-a"),
+                Some("https://jira.example"),
+                Some("org/PROJ"),
+            ),
+        ];
+        let resolved =
+            deduplicate_within_jira_project("proj::repo-a", &new, existing.iter(), Some("team"));
+        assert_ne!(resolved, "proj::repo-a");
+        assert_ne!(resolved, "proj::team-repo-a");
+        // Numeric fallback kicks in; accept any `proj::repo-a-N` form.
+        assert!(
+            resolved.starts_with("proj::repo-a-"),
+            "expected numeric fallback, got {resolved}"
+        );
+    }
+}

--- a/src/services/repo_project_label.rs
+++ b/src/services/repo_project_label.rs
@@ -65,12 +65,11 @@ pub fn sanitize(raw: &str) -> String {
         };
 
         match mapped {
-            Some('-') => {
-                if !last_was_dash && !buffer.is_empty() {
-                    buffer.push('-');
-                    last_was_dash = true;
-                }
+            Some('-') if !last_was_dash && !buffer.is_empty() => {
+                buffer.push('-');
+                last_was_dash = true;
             }
+            Some('-') => {}
             Some(c) => {
                 buffer.push(c);
                 last_was_dash = false;

--- a/src/services/sync_engine.rs
+++ b/src/services/sync_engine.rs
@@ -4,8 +4,9 @@ use crate::config::Config;
 use crate::domain::backend_state::backend_state_key;
 use crate::domain::issue::IssueDocument;
 use crate::error::RiptskError;
-use crate::models::{Backend, BackendConfig};
+use crate::models::{BackendKind, RepoProject};
 use crate::paths::AppPaths;
+use crate::services::backend_mapping;
 use crate::services::backend_mapping::{
     backend_state_entry, backend_to_local, copy_local_only_fields, current_timestamp,
     issue_to_upsert, update_issue_from_backend,
@@ -52,34 +53,32 @@ impl<'a> SyncEngine<'a> {
     pub async fn pull<P: IssueTracker + ?Sized>(
         &self,
         provider: &P,
-        backend: &BackendConfig,
+        repo_project: &RepoProject,
         force: bool,
         filter_ids: Option<&HashSet<String>>,
         force_ids: Option<&HashSet<String>>,
     ) -> Result<PullSummary, RiptskError> {
-        let repo = backend.repo.as_deref().ok_or_else(|| {
-            RiptskError::Config(format!("backend {} is missing repo", backend.name))
-        })?;
+        let repo = sync_repo(repo_project)?;
         let mut backend_state =
             cache::load_backend_state(self.paths).map_err(RiptskError::Other)?;
         let deleted_keys = cache::load_deleted_keys(self.paths).map_err(RiptskError::Other)?;
-        let records = provider.list_issues(repo).await?;
+        let records = provider.list_issues(&repo).await?;
         let mut summary = PullSummary::default();
         let mut seen_ids = HashSet::new();
 
         for record in records {
             let record_id =
-                issue_ids::format_id(&issue_ids::effective_key(backend), record.issue_id);
+                issue_ids::format_id(&issue_ids::effective_key(repo_project), record.issue_id);
             if filter_ids.is_some_and(|ids| !ids.contains(&record_id)) {
                 continue;
             }
-            let key = backend_state_key(provider_name(backend), repo, record.issue_id);
+            let key = backend_state_key(provider_name(repo_project), &repo, record.issue_id);
             seen_ids.insert(record.issue_id);
             if deleted_keys.contains(&key) {
                 continue;
             }
             let cached = backend_state.get(&key).cloned();
-            let local_path = self.find_local_issue(backend, record.issue_id)?;
+            let local_path = self.find_local_issue(repo_project, record.issue_id)?;
 
             if let Some(path) = local_path {
                 let mut issue = match frontmatter::try_load_issue(path.as_std_path()) {
@@ -105,16 +104,16 @@ impl<'a> SyncEngine<'a> {
                     && local_changed
                     && remote_changed
                 {
-                    self.write_conflict(backend, &record, &issue, &path)?;
+                    self.write_conflict(repo_project, &record, &issue, &path)?;
                     summary.conflicts.push(issue.frontmatter.id.clone());
                 } else if remote_changed {
-                    update_issue_from_backend(&mut issue, &record, backend);
+                    update_issue_from_backend(&mut issue, &record, repo_project);
                     frontmatter::save_issue(path.as_std_path(), &issue)
                         .map_err(RiptskError::Other)?;
                     summary.updated.push(issue.frontmatter.id.clone());
                 }
             } else {
-                let document = backend_to_local(&record, backend);
+                let document = backend_to_local(&record, repo_project);
                 let path = self
                     .paths
                     .issues_dir()
@@ -136,22 +135,30 @@ impl<'a> SyncEngine<'a> {
                         return Err(RiptskError::Other(error));
                     }
                 };
+                // Limit the deletion sweep to issues that belong to THIS
+                // RepoProject. Without this guard, a Jira shared-project pull
+                // (filtered by `repo_project_label`) would delete every other
+                // RepoProject's local issues because they share `project_key`
+                // but never appear in the label-filtered `seen_ids` set.
+                if issue.frontmatter.project != repo_project.name {
+                    continue;
+                }
                 let meta =
-                    match backend.backend {
-                        Backend::Github => issue.frontmatter.github.as_ref().and_then(|meta| {
+                    match repo_project.tasks_backend.kind {
+                        BackendKind::Github => issue.frontmatter.github.as_ref().and_then(|meta| {
                             (meta.repo == repo).then_some(meta.issue_id).flatten()
                         }),
-                        Backend::Gitlab => issue.frontmatter.gitlab.as_ref().and_then(|meta| {
+                        BackendKind::Gitlab => issue.frontmatter.gitlab.as_ref().and_then(|meta| {
                             (meta.repo == repo).then_some(meta.issue_id).flatten()
                         }),
-                        Backend::Jira => issue.frontmatter.jira.as_ref().and_then(|meta| {
+                        BackendKind::Jira => issue.frontmatter.jira.as_ref().and_then(|meta| {
                             let expected_key =
-                                crate::adapters::jira::JiraProvider::project_key(repo);
+                                crate::adapters::jira::JiraProvider::project_key(&repo);
                             (meta.project_key == expected_key)
                                 .then_some(meta.issue_id)
                                 .flatten()
                         }),
-                        Backend::Local => None,
+                        BackendKind::Local => None,
                     };
                 let Some(issue_id) = meta else {
                     continue;
@@ -160,7 +167,11 @@ impl<'a> SyncEngine<'a> {
                     continue;
                 }
                 issue_store::delete_issue_files(self.paths, &issue.frontmatter.id)?;
-                backend_state.remove(&backend_state_key(provider_name(backend), repo, issue_id));
+                backend_state.remove(&backend_state_key(
+                    provider_name(repo_project),
+                    &repo,
+                    issue_id,
+                ));
                 summary.deleted.push(issue.frontmatter.id.clone());
             }
         }
@@ -172,19 +183,21 @@ impl<'a> SyncEngine<'a> {
     pub async fn push<P: IssueTracker + ?Sized>(
         &self,
         provider: &P,
-        backend: &BackendConfig,
+        repo_project: &RepoProject,
     ) -> Result<PushSummary, RiptskError> {
         let issue_paths = issue_store::list_issues(self.paths)?;
-        self.push_inner(provider, backend, &issue_paths, true).await
+        self.push_inner(provider, repo_project, &issue_paths, true)
+            .await
     }
 
     pub async fn push_issues<P: IssueTracker + ?Sized>(
         &self,
         provider: &P,
-        backend: &BackendConfig,
+        repo_project: &RepoProject,
         issue_paths: &[camino::Utf8PathBuf],
     ) -> Result<PushSummary, RiptskError> {
-        self.push_inner(provider, backend, issue_paths, false).await
+        self.push_inner(provider, repo_project, issue_paths, false)
+            .await
     }
 
     pub fn status(&self) -> Result<StatusSummary, RiptskError> {
@@ -202,11 +215,11 @@ impl<'a> SyncEngine<'a> {
                 frontmatter::IssueLoadResult::Err(error) => return Err(RiptskError::Other(error)),
             };
 
-            let Some(project_backend) = self.backend_for_project(&issue.frontmatter.project) else {
+            let Some(repo_project) = self.project_for_name(&issue.frontmatter.project) else {
                 continue;
             };
 
-            let backend_key = issue_backend_key(&issue, project_backend);
+            let backend_key = issue_backend_key(&issue, repo_project);
             let Some(backend_key) = backend_key else {
                 summary.creates.push(issue.frontmatter.id.clone());
                 continue;
@@ -231,13 +244,11 @@ impl<'a> SyncEngine<'a> {
     async fn push_inner<P: IssueTracker + ?Sized>(
         &self,
         provider: &P,
-        backend: &BackendConfig,
+        repo_project: &RepoProject,
         issue_paths: &[camino::Utf8PathBuf],
         include_deletes: bool,
     ) -> Result<PushSummary, RiptskError> {
-        let repo = backend.repo.as_deref().ok_or_else(|| {
-            RiptskError::Config(format!("backend {} is missing repo", backend.name))
-        })?;
+        let repo = sync_repo(repo_project)?;
         let mut backend_state =
             cache::load_backend_state(self.paths).map_err(RiptskError::Other)?;
         let mut deleted_keys = cache::load_deleted_keys(self.paths).map_err(RiptskError::Other)?;
@@ -252,14 +263,15 @@ impl<'a> SyncEngine<'a> {
                 }
                 frontmatter::IssueLoadResult::Err(error) => return Err(RiptskError::Other(error)),
             };
-            if issue.frontmatter.project != backend.name || issue.frontmatter.remote_deleted {
+            if issue.frontmatter.project != repo_project.name || issue.frontmatter.remote_deleted {
                 continue;
             }
 
-            let upsert = issue_to_upsert(&issue);
-            let issue_id = issue_backend_issue_id(&issue, backend);
+            let upsert = issue_to_upsert(&issue, repo_project);
+            let outbound_labels = effective_outbound_labels(&upsert.labels, repo_project);
+            let issue_id = issue_backend_issue_id(&issue, repo_project);
             if let Some(issue_id) = issue_id {
-                let key = backend_state_key(provider_name(backend), repo, issue_id);
+                let key = backend_state_key(provider_name(repo_project), &repo, issue_id);
                 let cached = backend_state.get(&key);
                 if cached
                     .as_ref()
@@ -269,19 +281,21 @@ impl<'a> SyncEngine<'a> {
                     continue;
                 }
 
-                let mut record = provider.update_issue(repo, issue_id, &upsert).await?;
-                provider.sync_labels(repo, issue_id, &upsert.labels).await?;
-                sync_lock_state(provider, repo, issue_id, &issue, &record).await?;
+                let mut record = provider.update_issue(&repo, issue_id, &upsert).await?;
+                provider
+                    .sync_labels(&repo, issue_id, &outbound_labels)
+                    .await?;
+                sync_lock_state(provider, &repo, issue_id, &issue, &record).await?;
                 // Trigger state transitions (close/reopen) if the desired state
                 // differs from what the backend returned.
                 if let Some(ref desired_state) = upsert.state {
                     let is_closed = record.state.eq_ignore_ascii_case("closed");
                     if desired_state == "closed" && !is_closed {
                         provider
-                            .close_issue(repo, issue_id, upsert.state_reason.as_deref())
+                            .close_issue(&repo, issue_id, upsert.state_reason.as_deref())
                             .await?;
                     } else if desired_state == "open" && is_closed {
-                        provider.reopen_issue(repo, issue_id).await?;
+                        provider.reopen_issue(&repo, issue_id).await?;
                     }
                 }
                 if let Some(state) = upsert.state.clone() {
@@ -294,7 +308,7 @@ impl<'a> SyncEngine<'a> {
                 record.updated_at = current_timestamp();
 
                 let mut updated = issue;
-                update_issue_from_backend(&mut updated, &record, backend);
+                update_issue_from_backend(&mut updated, &record, repo_project);
                 frontmatter::save_issue(path.as_std_path(), &updated)
                     .map_err(RiptskError::Other)?;
                 backend_state.insert(key, backend_state_entry(&record));
@@ -302,20 +316,20 @@ impl<'a> SyncEngine<'a> {
                 continue;
             }
 
-            let mut record = provider.create_issue(repo, &upsert).await?;
+            let mut record = provider.create_issue(&repo, &upsert).await?;
             provider
-                .sync_labels(repo, record.issue_id, &upsert.labels)
+                .sync_labels(&repo, record.issue_id, &outbound_labels)
                 .await?;
             if issue.frontmatter.status == crate::domain::issue::IssueState::Done {
                 provider
-                    .close_issue(repo, record.issue_id, upsert.state_reason.as_deref())
+                    .close_issue(&repo, record.issue_id, upsert.state_reason.as_deref())
                     .await?;
                 record.state = "closed".into();
             } else {
-                provider.reopen_issue(repo, record.issue_id).await?;
+                provider.reopen_issue(&repo, record.issue_id).await?;
                 record.state = "open".into();
             }
-            sync_lock_state(provider, repo, record.issue_id, &issue, &record).await?;
+            sync_lock_state(provider, &repo, record.issue_id, &issue, &record).await?;
             record.state_reason = upsert.state_reason.clone();
             record.discussion_locked = issue.frontmatter.discussion_locked;
             record.locked = issue.frontmatter.locked;
@@ -323,10 +337,10 @@ impl<'a> SyncEngine<'a> {
             record.updated_at = current_timestamp();
 
             let mut created = issue;
-            update_issue_from_backend(&mut created, &record, backend);
+            update_issue_from_backend(&mut created, &record, repo_project);
             frontmatter::save_issue(path.as_std_path(), &created).map_err(RiptskError::Other)?;
             backend_state.insert(
-                backend_state_key(provider_name(backend), repo, record.issue_id),
+                backend_state_key(provider_name(repo_project), &repo, record.issue_id),
                 backend_state_entry(&record),
             );
             summary.created.push(created.frontmatter.id.clone());
@@ -339,10 +353,10 @@ impl<'a> SyncEngine<'a> {
                 let Some((key_provider, key_repo, issue_id)) = parse_backend_state_key(&key) else {
                     continue;
                 };
-                if key_provider != provider_name(backend) || key_repo != repo {
+                if key_provider != provider_name(repo_project) || key_repo != repo {
                     continue;
                 }
-                let outcome = provider.delete_issue(repo, issue_id).await?;
+                let outcome = provider.delete_issue(&repo, issue_id).await?;
                 if outcome == DeleteOutcome::HardDeleted {
                     deleted_keys.remove(&key);
                 }
@@ -358,10 +372,10 @@ impl<'a> SyncEngine<'a> {
 
     fn find_local_issue(
         &self,
-        backend: &BackendConfig,
+        repo_project: &RepoProject,
         issue_id: u64,
     ) -> Result<Option<camino::Utf8PathBuf>, RiptskError> {
-        let exact_id = issue_ids::format_id(&issue_ids::effective_key(backend), issue_id);
+        let exact_id = issue_ids::format_id(&issue_ids::effective_key(repo_project), issue_id);
         if let Ok(path) = issue_store::find_issue(self.paths, &exact_id) {
             return Ok(Some(path));
         }
@@ -372,22 +386,26 @@ impl<'a> SyncEngine<'a> {
                 frontmatter::IssueLoadResult::Conflict { .. } => continue,
                 frontmatter::IssueLoadResult::Err(error) => return Err(RiptskError::Other(error)),
             };
-            let matches = match backend.backend {
-                Backend::Github => issue.frontmatter.github.as_ref().is_some_and(|meta| {
-                    meta.repo == backend.repo.clone().unwrap_or_default()
+            let matches = match repo_project.tasks_backend.kind {
+                BackendKind::Github => issue.frontmatter.github.as_ref().is_some_and(|meta| {
+                    meta.repo == repo_project.tasks_backend.repo.clone().unwrap_or_default()
                         && meta.issue_id == Some(issue_id)
                 }),
-                Backend::Gitlab => issue.frontmatter.gitlab.as_ref().is_some_and(|meta| {
-                    meta.repo == backend.repo.clone().unwrap_or_default()
+                BackendKind::Gitlab => issue.frontmatter.gitlab.as_ref().is_some_and(|meta| {
+                    meta.repo == repo_project.tasks_backend.repo.clone().unwrap_or_default()
                         && meta.issue_id == Some(issue_id)
                 }),
-                Backend::Jira => issue.frontmatter.jira.as_ref().is_some_and(|meta| {
+                BackendKind::Jira => issue.frontmatter.jira.as_ref().is_some_and(|meta| {
                     let expected_key = crate::adapters::jira::JiraProvider::project_key(
-                        backend.repo.as_deref().unwrap_or_default(),
+                        repo_project
+                            .tasks_backend
+                            .jira_project
+                            .as_deref()
+                            .unwrap_or_default(),
                     );
                     meta.project_key == expected_key && meta.issue_id == Some(issue_id)
                 }),
-                Backend::Local => false,
+                BackendKind::Local => false,
             };
             if matches {
                 return Ok(Some(path));
@@ -396,19 +414,19 @@ impl<'a> SyncEngine<'a> {
         Ok(None)
     }
 
-    fn backend_for_project(&self, project: &str) -> Option<&BackendConfig> {
-        self.config.backends.iter().find(|backend| {
-            backend.name == project
+    fn project_for_name(&self, project: &str) -> Option<&RepoProject> {
+        self.config.projects.iter().find(|repo_project| {
+            repo_project.name == project
                 && matches!(
-                    backend.backend,
-                    Backend::Github | Backend::Gitlab | Backend::Jira
+                    repo_project.tasks_backend.kind,
+                    BackendKind::Github | BackendKind::Gitlab | BackendKind::Jira
                 )
         })
     }
 
     fn write_conflict(
         &self,
-        backend: &BackendConfig,
+        repo_project: &RepoProject,
         record: &BackendIssueRecord,
         issue: &IssueDocument,
         issue_path: &camino::Utf8PathBuf,
@@ -416,7 +434,7 @@ impl<'a> SyncEngine<'a> {
         let local_path = issue_store::local_backup_path(self.paths, &issue.frontmatter.id);
         fs::copy(issue_path, &local_path)?;
 
-        let mut remote_doc = backend_to_local(record, backend);
+        let mut remote_doc = backend_to_local(record, repo_project);
         copy_local_only_fields(&mut remote_doc.frontmatter, &issue.frontmatter);
         let remote_path = issue_store::remote_backup_path(self.paths, &issue.frontmatter.id);
         frontmatter::save_issue(remote_path.as_std_path(), &remote_doc)
@@ -459,40 +477,81 @@ async fn sync_lock_state<P: IssueTracker + ?Sized>(
     }
 }
 
-fn provider_name(backend: &BackendConfig) -> &'static str {
-    match backend.backend {
-        Backend::Github => "github",
-        Backend::Gitlab => "gitlab",
-        Backend::Jira => "jira",
-        Backend::Local => "local",
+fn provider_name(repo_project: &RepoProject) -> &'static str {
+    match repo_project.tasks_backend.kind {
+        BackendKind::Github => "github",
+        BackendKind::Gitlab => "gitlab",
+        BackendKind::Jira => "jira",
+        BackendKind::Local => "local",
     }
 }
 
-fn issue_backend_issue_id(issue: &IssueDocument, backend: &BackendConfig) -> Option<u64> {
-    match backend.backend {
-        Backend::Github => issue
+fn issue_backend_issue_id(issue: &IssueDocument, repo_project: &RepoProject) -> Option<u64> {
+    match repo_project.tasks_backend.kind {
+        BackendKind::Github => issue
             .frontmatter
             .github
             .as_ref()
             .and_then(|meta| meta.issue_id),
-        Backend::Gitlab => issue
+        BackendKind::Gitlab => issue
             .frontmatter
             .gitlab
             .as_ref()
             .and_then(|meta| meta.issue_id),
-        Backend::Jira => issue
+        BackendKind::Jira => issue
             .frontmatter
             .jira
             .as_ref()
             .and_then(|meta| meta.issue_id),
-        Backend::Local => None,
+        BackendKind::Local => None,
     }
 }
 
-fn issue_backend_key(issue: &IssueDocument, backend: &BackendConfig) -> Option<String> {
-    let repo = backend.repo.as_deref()?;
-    let issue_id = issue_backend_issue_id(issue, backend)?;
-    Some(backend_state_key(provider_name(backend), repo, issue_id))
+fn issue_backend_key(issue: &IssueDocument, repo_project: &RepoProject) -> Option<String> {
+    let repo = sync_repo(repo_project).ok()?;
+    let issue_id = issue_backend_issue_id(issue, repo_project)?;
+    Some(backend_state_key(
+        provider_name(repo_project),
+        &repo,
+        issue_id,
+    ))
+}
+
+fn sync_repo(repo_project: &RepoProject) -> Result<String, RiptskError> {
+    match repo_project.tasks_backend.kind {
+        BackendKind::Github | BackendKind::Gitlab => {
+            repo_project.tasks_backend.repo.clone().ok_or_else(|| {
+                RiptskError::Config(format!(
+                    "RepoProject {} is missing TasksBackend repo",
+                    repo_project.name
+                ))
+            })
+        }
+        BackendKind::Jira => repo_project
+            .tasks_backend
+            .jira_project
+            .clone()
+            .ok_or_else(|| {
+                RiptskError::Config(format!(
+                    "RepoProject {} is missing JiraProject",
+                    repo_project.name
+                ))
+            }),
+        BackendKind::Local => Err(RiptskError::Config(format!(
+            "RepoProject {} does not have a hosted TasksBackend",
+            repo_project.name
+        ))),
+    }
+}
+
+fn effective_outbound_labels(base: &[String], repo_project: &RepoProject) -> Vec<String> {
+    let mut labels = base.to_vec();
+    if let Some(label) = backend_mapping::effective_repo_project_label(repo_project)
+        && !labels.iter().any(|candidate| candidate == label)
+    {
+        labels.push(label.to_owned());
+    }
+    labels
 }
 
 fn parse_backend_state_key(key: &str) -> Option<(&str, &str, u64)> {
@@ -1302,7 +1361,7 @@ mod tests {
             .expect("runtime")
     }
 
-    fn test_context() -> (AppPaths, Config, BackendConfig) {
+    fn test_context() -> (AppPaths, Config, RepoProject) {
         let temp = tempdir().expect("temp dir");
         let root = temp.path().to_path_buf();
         std::mem::forget(temp);
@@ -1314,20 +1373,29 @@ mod tests {
             state_root: root.join("state").to_string_lossy().as_ref().into(),
         };
         paths.ensure_repo_dirs().expect("repo dirs");
-        let backend = BackendConfig {
+        let backend = RepoProject {
             name: "remote-project".into(),
-            backend: Backend::Github,
-            host: None,
-            repo: Some("owner/repo".into()),
+            vc_backend: crate::models::VCBackendSpec {
+                kind: BackendKind::Github,
+                host: None,
+                repo: Some("owner/repo".into()),
+                path: None,
+            },
+            tasks_backend: crate::models::TasksBackendSpec {
+                kind: BackendKind::Github,
+                host: None,
+                repo: Some("owner/repo".into()),
+                jira_project: None,
+                default_issue_type: None,
+                path: None,
+            },
             default_board: Some("personal".into()),
             default_org: None,
-            path: None,
-            vc: None,
-            default_issue_type: None,
             key: Some("GH-OWN-REP".into()),
+            repo_project_label: None,
         };
         let mut config = default_config();
-        config.backends = vec![backend.clone()];
+        config.projects = vec![backend.clone()];
         (paths, config, backend)
     }
 
@@ -1524,12 +1592,12 @@ mod tests {
             .expect("load issue")
     }
 
-    fn seed_backend_state(paths: &AppPaths, backend: &BackendConfig, record: &BackendIssueRecord) {
+    fn seed_backend_state(paths: &AppPaths, backend: &RepoProject, record: &BackendIssueRecord) {
         let mut state = HashMap::new();
         state.insert(
             backend_state_key(
                 provider_name(backend),
-                backend.repo.as_deref().expect("repo"),
+                &sync_repo(backend).expect("repo"),
                 record.issue_id,
             ),
             backend_state_entry(record),

--- a/tests/cmd_id_resolution.rs
+++ b/tests/cmd_id_resolution.rs
@@ -198,14 +198,18 @@ defaults:
   priority: medium
   assignee: ~
   template: task
-backends:
+projects:
   - name: dev-tools
-    type: github
-    repo: GubCorp/dev-tools
+    vc_backend:
+      type: github
+      repo: GubCorp/dev-tools
+      path: {}
+    tasks_backend:
+      type: github
+      repo: GubCorp/dev-tools
     key: GH-GUB-DEV
     default_board: personal
     default_org: ~
-    path: {}
 boards:
   - name: personal
     statuses: [backlog, todo, in-progress, review, done]

--- a/tests/cmd_register.rs
+++ b/tests/cmd_register.rs
@@ -1,22 +1,36 @@
 use camino::Utf8PathBuf;
 use riptsk::config::default_config;
 use riptsk::error::RiptskError;
-use riptsk::models::{Backend, BackendConfig};
+use riptsk::models::{BackendKind, RepoProject, TasksBackendSpec, VCBackendSpec};
 use riptsk::services::project_detection::register_project_auto;
 use tempfile::tempdir;
 
-fn backend(kind: Backend, name: &str, path: Option<&str>, key: Option<&str>) -> BackendConfig {
-    BackendConfig {
+fn repo_project(
+    kind: BackendKind,
+    name: &str,
+    path: Option<&str>,
+    key: Option<&str>,
+) -> RepoProject {
+    RepoProject {
         name: name.into(),
-        backend: kind,
-        host: None,
-        repo: None,
+        vc_backend: VCBackendSpec {
+            kind: kind.clone(),
+            host: None,
+            repo: None,
+            path: path.map(str::to_owned),
+        },
+        tasks_backend: TasksBackendSpec {
+            kind,
+            host: None,
+            repo: None,
+            jira_project: None,
+            default_issue_type: None,
+            path: path.map(str::to_owned),
+        },
         default_board: Some("personal".into()),
         default_org: None,
-        path: path.map(str::to_owned),
-        vc: None,
-        default_issue_type: None,
         key: key.map(str::to_owned),
+        repo_project_label: None,
     }
 }
 
@@ -28,12 +42,12 @@ fn auto_register_assigns_derived_key() {
     let cwd = Utf8PathBuf::from_path_buf(plain_dir).expect("utf8 path");
     let mut config = default_config();
 
-    let backend = register_project_auto(&cwd, &mut config, None, None)
+    let repo_project = register_project_auto(&cwd, &mut config, None, None)
         .expect("register")
-        .expect("backend");
+        .expect("repo project");
 
-    assert_eq!(backend.key.as_deref(), Some("MYPROJ"));
-    assert_eq!(config.backends.len(), 1);
+    assert_eq!(repo_project.key.as_deref(), Some("MYPROJ"));
+    assert_eq!(config.projects.len(), 1);
 }
 
 #[test]
@@ -47,16 +61,16 @@ fn auto_register_collision_without_prompts_returns_key_collision_and_does_not_mu
     let existing_path = existing_dir.to_string_lossy().to_string();
 
     let mut config = default_config();
-    config.backends.push(backend(
-        Backend::Local,
+    config.projects.push(repo_project(
+        BackendKind::Local,
         "existing",
         Some(&existing_path),
         Some("FOO"),
     ));
-    let before = config.backends.len();
+    let before = config.projects.len();
 
     let error = register_project_auto(&cwd, &mut config, None, None).expect_err("collision");
 
     assert!(matches!(error, RiptskError::KeyCollision(_)));
-    assert_eq!(config.backends.len(), before);
+    assert_eq!(config.projects.len(), before);
 }

--- a/tests/fixtures/riptsk.yaml
+++ b/tests/fixtures/riptsk.yaml
@@ -5,11 +5,16 @@ defaults:
   priority: medium
   assignee: tester
   template: task
-backends:
+projects:
   - name: wormhole-router
-    type: gitlab
-    host: https://gitlab.example.com
-    repo: chrono/wormhole-router
+    vc_backend:
+      type: gitlab
+      host: https://gitlab.example.com
+      repo: chrono/wormhole-router
+    tasks_backend:
+      type: gitlab
+      host: https://gitlab.example.com
+      repo: chrono/wormhole-router
     key: GL-CHR-WOR
     default_board: personal
     default_org: chrono

--- a/tests/fixtures/riptsk_multi.yaml
+++ b/tests/fixtures/riptsk_multi.yaml
@@ -5,24 +5,36 @@ defaults:
   priority: medium
   assignee: tester
   template: task
-backends:
+projects:
   - name: wormhole-router
-    type: gitlab
-    host: https://gitlab.example.com
-    repo: chrono/wormhole-router
+    vc_backend:
+      type: gitlab
+      host: https://gitlab.example.com
+      repo: chrono/wormhole-router
+    tasks_backend:
+      type: gitlab
+      host: https://gitlab.example.com
+      repo: chrono/wormhole-router
     key: GL-CHR-WOR
     default_board: penguin-chrono-labs
     default_org: chrono
   - name: fish-from-the-future
-    type: github
-    repo: Penguin-Chrono-Labs/fish-from-the-future
+    vc_backend:
+      type: github
+      repo: Penguin-Chrono-Labs/fish-from-the-future
+    tasks_backend:
+      type: github
+      repo: Penguin-Chrono-Labs/fish-from-the-future
     key: GH-PEN-FIS
     default_board: penguin-chrono-labs
     default_org: chrono
   - name: penguin-scratch
-    type: local
-    repo: ~
-    path: /tmp/penguin-scratch
+    vc_backend:
+      type: local
+      path: /tmp/penguin-scratch
+    tasks_backend:
+      type: local
+      path: /tmp/penguin-scratch
     key: LO-PEN
     default_board: personal
     default_org: ~

--- a/tests/snapshots/format_contracts__riptsk_multi_yaml.snap
+++ b/tests/snapshots/format_contracts__riptsk_multi_yaml.snap
@@ -10,24 +10,37 @@ defaults:
   priority: medium
   assignee: tester
   template: task
-backends:
+projects:
 - name: wormhole-router
-  type: gitlab
-  host: https://gitlab.example.com
-  repo: chrono/wormhole-router
+  vc_backend:
+    type: gitlab
+    host: https://gitlab.example.com
+    repo: chrono/wormhole-router
+  tasks_backend:
+    type: gitlab
+    host: https://gitlab.example.com
+    repo: chrono/wormhole-router
   default_board: penguin-chrono-labs
   default_org: chrono
   key: GL-CHR-WOR
 - name: fish-from-the-future
-  type: github
-  repo: Penguin-Chrono-Labs/fish-from-the-future
+  vc_backend:
+    type: github
+    repo: Penguin-Chrono-Labs/fish-from-the-future
+  tasks_backend:
+    type: github
+    repo: Penguin-Chrono-Labs/fish-from-the-future
   default_board: penguin-chrono-labs
   default_org: chrono
   key: GH-PEN-FIS
 - name: penguin-scratch
-  type: local
+  vc_backend:
+    type: local
+    path: /tmp/penguin-scratch
+  tasks_backend:
+    type: local
+    path: /tmp/penguin-scratch
   default_board: personal
-  path: /tmp/penguin-scratch
   key: LO-PEN
 boards:
 - name: penguin-chrono-labs

--- a/tests/snapshots/format_contracts__riptsk_yaml.snap
+++ b/tests/snapshots/format_contracts__riptsk_yaml.snap
@@ -10,11 +10,16 @@ defaults:
   priority: medium
   assignee: tester
   template: task
-backends:
+projects:
 - name: wormhole-router
-  type: gitlab
-  host: https://gitlab.example.com
-  repo: chrono/wormhole-router
+  vc_backend:
+    type: gitlab
+    host: https://gitlab.example.com
+    repo: chrono/wormhole-router
+  tasks_backend:
+    type: gitlab
+    host: https://gitlab.example.com
+    repo: chrono/wormhole-router
   default_board: personal
   default_org: chrono
   key: GL-CHR-WOR


### PR DESCRIPTION
Closes #136

## Summary

This commit standardizes terminology across the codebase by introducing RepoProject as the canonical concept for representing coding projects. It establishes clear distinction between project configuration (RepoProject with separate vc_backend and tasks_backend specs) and external providers (BackendKind). All documentation and code identifiers now use precise terminology aligned with the new architecture.

## Key Changes

- **Added comprehensive Terminology glossary to CLAUDE.md** — Defines RepoProject, VCBackend, TasksBackend, BackendKind, RepoProject label, RepoProject key, and JiraProject with precise meanings and usage rules
- **Updated config schema in README.md** — Renamed `backends:` to `projects:` and split configuration into separate `vc_backend` and `tasks_backend` specs with explicit `type` and provider fields
- **Standardized terminology across documentation** — Replaced generic "projects" with "RepoProjects" throughout problem statement and design principles docs
- **Banned bare "Backend" term** — Established rule to use explicit VCBackend/TasksBackend/BackendKind instead of ambiguous "Backend"
- **Added Jira partitioning reference** — Documented RepoProject label usage for partitioning shared Jira projects in README

Closes the gap between old `BackendConfig` abstraction and new RepoProject-centric architecture, ensuring all documentation and code identifiers align on precise terminology.